### PR TITLE
Add prefix getter to main Client implementation + some refactors

### DIFF
--- a/tanjun/checks.py
+++ b/tanjun/checks.py
@@ -280,7 +280,7 @@ def with_dm_check(command: CommandT, /) -> CommandT:
     CommandT
         The command this check was added to.
     """
-    command.add_check(dm_check)
+    command.append_check(dm_check)
     return command
 
 
@@ -297,7 +297,7 @@ def with_guild_check(command: CommandT, /) -> CommandT:
     CommandT
         The command this check was added to.
     """
-    command.add_check(guild_check)
+    command.append_check(guild_check)
     return command
 
 
@@ -314,7 +314,7 @@ def with_nsfw_check(command: CommandT, /) -> CommandT:
     CommandT
         The command this check was added to.
     """
-    command.add_check(nsfw_check)
+    command.append_check(nsfw_check)
     return command
 
 
@@ -331,7 +331,7 @@ def with_sfw_check(command: CommandT, /) -> CommandT:
     CommandT
         The command this check was added to.
     """
-    command.add_check(sfw_check)
+    command.append_check(sfw_check)
     return command
 
 
@@ -352,7 +352,7 @@ def with_owner_check(command: CommandT, /) -> CommandT:
     CommandT
         The command this check was added to.
     """
-    command.add_check(ApplicationOwnerCheck())
+    command.append_check(ApplicationOwnerCheck())
     return command
 
 
@@ -376,7 +376,7 @@ def with_author_permission_check(
     """
 
     def decorator(command: CommandT, /) -> CommandT:
-        command.add_check(AuthorPermissionCheck(permissions))
+        command.append_check(AuthorPermissionCheck(permissions))
         return command
 
     return decorator
@@ -402,7 +402,7 @@ def with_own_permission_check(
     """
 
     def decorator(command: CommandT, /) -> CommandT:
-        command.add_check(BotPermissionsCheck(permissions))
+        command.append_check(BotPermissionsCheck(permissions))
         return command
 
     return decorator

--- a/tanjun/checks.py
+++ b/tanjun/checks.py
@@ -280,7 +280,7 @@ def with_dm_check(command: CommandT, /) -> CommandT:
     CommandT
         The command this check was added to.
     """
-    command.append_check(dm_check)
+    command.add_check(dm_check)
     return command
 
 
@@ -297,7 +297,7 @@ def with_guild_check(command: CommandT, /) -> CommandT:
     CommandT
         The command this check was added to.
     """
-    command.append_check(guild_check)
+    command.add_check(guild_check)
     return command
 
 
@@ -314,7 +314,7 @@ def with_nsfw_check(command: CommandT, /) -> CommandT:
     CommandT
         The command this check was added to.
     """
-    command.append_check(nsfw_check)
+    command.add_check(nsfw_check)
     return command
 
 
@@ -331,7 +331,7 @@ def with_sfw_check(command: CommandT, /) -> CommandT:
     CommandT
         The command this check was added to.
     """
-    command.append_check(sfw_check)
+    command.add_check(sfw_check)
     return command
 
 
@@ -352,7 +352,7 @@ def with_owner_check(command: CommandT, /) -> CommandT:
     CommandT
         The command this check was added to.
     """
-    command.append_check(ApplicationOwnerCheck())
+    command.add_check(ApplicationOwnerCheck())
     return command
 
 
@@ -376,7 +376,7 @@ def with_author_permission_check(
     """
 
     def decorator(command: CommandT, /) -> CommandT:
-        command.append_check(AuthorPermissionCheck(permissions))
+        command.add_check(AuthorPermissionCheck(permissions))
         return command
 
     return decorator
@@ -402,7 +402,7 @@ def with_own_permission_check(
     """
 
     def decorator(command: CommandT, /) -> CommandT:
-        command.append_check(BotPermissionsCheck(permissions))
+        command.add_check(BotPermissionsCheck(permissions))
         return command
 
     return decorator

--- a/tanjun/checks.py
+++ b/tanjun/checks.py
@@ -66,8 +66,8 @@ if typing.TYPE_CHECKING:
     from tanjun import traits as tanjun_traits
 
 
-CommandT = typing.TypeVar(
-    "CommandT", "tanjun_traits.CommandDescriptor", "tanjun_traits.ExecutableCommand", contravariant=True
+CommandT_contra = typing.TypeVar(
+    "CommandT_contra", "tanjun_traits.CommandDescriptor", "tanjun_traits.ExecutableCommand", contravariant=True
 )
 
 
@@ -267,75 +267,75 @@ class BotPermissionsCheck(PermissionCheck):
         return self._me
 
 
-def with_dm_check(command: CommandT, /) -> CommandT:
+def with_dm_check(command: CommandT_contra, /) -> CommandT_contra:
     """Only let a command run in a DM channel.
 
     Parameters
     ----------
-    command : CommandT
+    command : CommandT_contra
         The command to add this check to.
 
     Returns
     -------
-    CommandT
+    CommandT_contra
         The command this check was added to.
     """
     command.add_check(dm_check)
     return command
 
 
-def with_guild_check(command: CommandT, /) -> CommandT:
+def with_guild_check(command: CommandT_contra, /) -> CommandT_contra:
     """Only let a command run in a guild channel.
 
     Parameters
     ----------
-    command : CommandT
+    command : CommandT_contra
         The command to add this check to.
 
     Returns
     -------
-    CommandT
+    CommandT_contra
         The command this check was added to.
     """
     command.add_check(guild_check)
     return command
 
 
-def with_nsfw_check(command: CommandT, /) -> CommandT:
+def with_nsfw_check(command: CommandT_contra, /) -> CommandT_contra:
     """Only let a command run in a channel that's marked as nsfw.
 
     Parameters
     ----------
-    command : CommandT
+    command : CommandT_contra
         The command to add this check to.
 
     Returns
     -------
-    CommandT
+    CommandT_contra
         The command this check was added to.
     """
     command.add_check(nsfw_check)
     return command
 
 
-def with_sfw_check(command: CommandT, /) -> CommandT:
+def with_sfw_check(command: CommandT_contra, /) -> CommandT_contra:
     """Only let a command run in a channel that's marked as sfw.
 
     Parameters
     ----------
-    command : CommandT
+    command : CommandT_contra
         The command to add this check to.
 
     Returns
     -------
-    CommandT
+    CommandT_contra
         The command this check was added to.
     """
     command.add_check(sfw_check)
     return command
 
 
-def with_owner_check(command: CommandT, /) -> CommandT:
+def with_owner_check(command: CommandT_contra, /) -> CommandT_contra:
     """Only let a command run if it's being triggered by one of the bot's owners.
 
     !!! note
@@ -344,12 +344,12 @@ def with_owner_check(command: CommandT, /) -> CommandT:
 
     Parameters
     ----------
-    command : CommandT
+    command : CommandT_contra
         The command to add this check to.
 
     Returns
     -------
-    CommandT
+    CommandT_contra
         The command this check was added to.
     """
     command.add_check(ApplicationOwnerCheck())
@@ -358,7 +358,7 @@ def with_owner_check(command: CommandT, /) -> CommandT:
 
 def with_author_permission_check(
     permissions: typing.Union[permissions_.Permissions, int], /
-) -> typing.Callable[[CommandT], CommandT]:
+) -> typing.Callable[[CommandT_contra], CommandT_contra]:
     """Only let a command run if the author has certain permissions in the current channel.
 
     !!! note
@@ -371,11 +371,11 @@ def with_author_permission_check(
 
     Returns
     -------
-    typing.Callable[[CommandT], CommandT]
+    typing.Callable[[CommandT_contra], CommandT_contra]
         A command decorator function which adds the check.
     """
 
-    def decorator(command: CommandT, /) -> CommandT:
+    def decorator(command: CommandT_contra, /) -> CommandT_contra:
         command.add_check(AuthorPermissionCheck(permissions))
         return command
 
@@ -384,7 +384,7 @@ def with_author_permission_check(
 
 def with_own_permission_check(
     permissions: typing.Union[permissions_.Permissions, int], /
-) -> typing.Callable[[CommandT], CommandT]:
+) -> typing.Callable[[CommandT_contra], CommandT_contra]:
     """Only let a command run if we have certain permissions in the current channel.
 
     !!! note
@@ -397,11 +397,11 @@ def with_own_permission_check(
 
     Returns
     -------
-    typing.Callable[[CommandT], CommandT]
+    typing.Callable[[CommandT_contra], CommandT_contra]
         A command decorator function which adds the check.
     """
 
-    def decorator(command: CommandT, /) -> CommandT:
+    def decorator(command: CommandT_contra, /) -> CommandT_contra:
         command.add_check(BotPermissionsCheck(permissions))
         return command
 

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -102,12 +102,32 @@ def as_loader(function: traits.LoadableT) -> traits.LoadableT:
 
 
 class AcceptsEnum(str, enum.Enum):
+    """The possible configurations for which events `Client` should execute commands based on."""
+
     ALL = "ALL"
+    """Set the client to execute commands based on both DM and guild message create events."""
+
     DM_ONLY = "DM_ONLY"
+    """Set the client to execute commands based only DM message create events."""
+
     GUILD_ONLY = "GUILD_ONLY"
+    """Set the client to execute commands based only guild message create events."""
+
     NONE = "NONE"
+    """Set the client to not execute commands based on message create events."""
 
     def get_event_type(self) -> typing.Optional[typing.Type[message_events.MessageCreateEvent]]:
+        """Get the base event type this mode listens to.
+
+        Returns
+        -------
+        typing.Optional[typing.Type[hikari.message_events.MessageCreateEvent]]
+            The type object of the MessageCreateEvent class this mode will
+            register a listener for.
+
+            This will be `builtins.None` if this mode disables listening to
+            message create events/
+        """
         return _ACCEPTS_EVENT_TYPE_MAPPING[self]
 
 

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -277,11 +277,8 @@ class Client(traits.Client):
         return await utilities.gather_checks(utilities.await_if_async(check, ctx) for check in self._checks)
 
     def add_component(self: ClientT, component: traits.Component, /) -> ClientT:
-        self.add_component(component)
-        return self
-
-    def append_component(self, component: traits.Component, /) -> None:
         self._components.add(component)
+        return self
 
     def remove_component(self, component: traits.Component, /) -> None:
         self._components.remove(component)

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -193,11 +193,11 @@ class Client(traits.Client):
         self._prefixes: typing.Set[str] = set()
         self._rest = rest
         self._shards = shard
+        self.set_human_only(True)
 
         if event_managed:
             self._events.event_manager.subscribe(lifetime_events.StartingEvent, self._on_starting_event)
             self._events.event_manager.subscribe(lifetime_events.StoppingEvent, self._on_stopping_event)
-        self.set_human_only(True)
 
     async def __aenter__(self) -> Client:
         await self.open()

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -334,7 +334,7 @@ class Client(traits.Client):
         if event.message.content is None:
             return
 
-        ctx = context.Context(self, content=event.message.content, message=event.message, triggering_prefix="")
+        ctx = context.Context(self, content=event.message.content, message=event.message)
         if (prefix := await self._check_prefix(ctx)) is None:
             return
 

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -208,31 +208,31 @@ class Client(traits.Client):
     async def _on_stopping_event(self, _: lifetime_events.StoppingEvent, /) -> None:
         await self.close()
 
+    def add_check(self: ClientT, check: traits.CheckT, /) -> ClientT:
+        self._checks.add(check)
+        return self
+
     def remove_check(self, check: traits.CheckT, /) -> None:
         self._checks.remove(check)
 
-    def with_check(self: ClientT, check: traits.CheckT, /) -> ClientT:
-        self._checks.add(check)
-        return self
+    def with_check(self, check: traits.CheckT, /) -> traits.CheckT:
+        self.add_check(check)
+        return check
 
     async def check(self, ctx: traits.Context, /) -> bool:
         return await utilities.gather_checks(utilities.await_if_async(check, ctx) for check in self._checks)
 
-    def add_component(self, component: traits.Component, /) -> None:
-        component.bind_client(self)
+    def add_component(self: ClientT, component: traits.Component, /) -> ClientT:
+        self.add_component(component)
+        return self
+
+    def append_component(self, component: traits.Component, /) -> None:
         self._components.add(component)
 
     def remove_component(self, component: traits.Component, /) -> None:
         self._components.remove(component)
 
-    def with_component(self: ClientT, component: traits.Component, /) -> ClientT:
-        self.add_component(component)
-        return self
-
-    def remove_prefix(self, prefix: str, /) -> None:
-        self._prefixes.remove(prefix)
-
-    def with_prefixes(self: ClientT, prefixes: typing.Union[typing.Iterable[str], str], /) -> ClientT:
+    def add_prefix(self: ClientT, prefixes: typing.Union[typing.Iterable[str], str], /) -> ClientT:
         if isinstance(prefixes, str):
             self._prefixes.add(prefixes)
 
@@ -240,6 +240,9 @@ class Client(traits.Client):
             self._prefixes.update(prefixes)
 
         return self
+
+    def remove_prefix(self, prefix: str, /) -> None:
+        self._prefixes.remove(prefix)
 
     def set_prefix_getter(self: ClientT, getter: typing.Optional[PrefixGetterT], /) -> ClientT:
         self._prefix_getter = getter
@@ -308,11 +311,11 @@ class Client(traits.Client):
         if register_listener:
             self._events.event_manager.subscribe(message_events.MessageCreateEvent, self.on_message_create)
 
-    def with_hooks(self: ClientT, hooks: typing.Optional[traits.Hooks], /) -> ClientT:
+    def set_hooks(self: ClientT, hooks: typing.Optional[traits.Hooks], /) -> ClientT:
         self.hooks = hooks
         return self
 
-    def with_modules(self: ClientT, modules: typing.Iterable[typing.Union[str, pathlib.Path]], /) -> ClientT:
+    def load_modules(self: ClientT, modules: typing.Iterable[typing.Union[str, pathlib.Path]], /) -> ClientT:
         for module_path in modules:
             if isinstance(module_path, str):
                 module = importlib.import_module(module_path)

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -108,10 +108,10 @@ class AcceptsEnum(str, enum.Enum):
     NONE = "NONE"
 
     def get_event_type(self) -> typing.Optional[typing.Type[message_events.MessageCreateEvent]]:
-        return __ACCEPTS_EVENT_TYPE_MAPPING[self]
+        return _ACCEPTS_EVENT_TYPE_MAPPING[self]
 
 
-__ACCEPTS_EVENT_TYPE_MAPPING: typing.Dict[
+_ACCEPTS_EVENT_TYPE_MAPPING: typing.Dict[
     AcceptsEnum, typing.Optional[typing.Type[message_events.MessageCreateEvent]]
 ] = {
     AcceptsEnum.ALL: message_events.MessageCreateEvent,
@@ -277,6 +277,7 @@ class Client(traits.Client):
         return await utilities.gather_checks(utilities.await_if_async(check, ctx) for check in self._checks)
 
     def add_component(self: _ClientT, component: traits.Component, /) -> _ClientT:
+        component.bind_client(self)
         self._components.add(component)
         return self
 

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -320,6 +320,11 @@ class Client(traits.Client):
         self._prefix_getter = getter
         return self
 
+    # TODO: use generic callable type var here instead?
+    def with_prefix_getter(self: _ClientT, getter: PrefixGetterT) -> PrefixGetterT:
+        self.set_prefix_getter(getter)
+        return getter
+
     async def check_context(self, ctx: traits.Context, /) -> typing.AsyncIterator[traits.FoundCommand]:
         async for value in utilities.async_chain(component.check_context(ctx) for component in self._components):
             yield value

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -31,7 +31,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from __future__ import annotations
 
-__all__: typing.Sequence[str] = ["as_loader", "Client"]
+__all__: typing.Sequence[str] = ["as_loader", "Client", "PrefixGetterT"]
 
 import asyncio
 import importlib.util
@@ -56,7 +56,14 @@ if typing.TYPE_CHECKING:
     from hikari import users
 
     ClientT = typing.TypeVar("ClientT", bound="Client")
-    PrefixGetterT = typing.Callable[[traits.Context], typing.Awaitable[typing.Iterable[str]]]
+
+
+PrefixGetterT = typing.Callable[[traits.Context], typing.Awaitable[typing.Iterable[str]]]
+"""Type hint of a callable used to get the prefix(es) for a specific guild.
+
+This should be an asynchronous callable which takes one positional argument of
+type `tanjun.traits.Context` and returns an iterable of strings.
+"""
 
 
 class _LoadableDescriptor(traits.LoadableDescriptor):

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -56,6 +56,7 @@ if typing.TYPE_CHECKING:
     from hikari import users
 
     ClientT = typing.TypeVar("ClientT", bound="Client")
+    PrefixGetterT = typing.Callable[[traits.Context], typing.Awaitable[typing.Iterable[str]]]
 
 
 class _LoadableDescriptor(traits.LoadableDescriptor):
@@ -100,8 +101,8 @@ class Client(traits.Client):
         "_events",
         "hooks",
         "_metadata",
-        "_prefixes",
         "_prefix_getter",
+        "_prefixes",
         "_rest",
         "_shards",
     )
@@ -134,10 +135,8 @@ class Client(traits.Client):
         self._events = events
         self.hooks: typing.Optional[traits.Hooks] = None
         self._metadata: typing.Dict[typing.Any, typing.Any] = {}
+        self._prefix_getter: typing.Optional[PrefixGetterT] = None
         self._prefixes: typing.Set[str] = set()
-        self._prefix_getter: typing.Optional[
-            typing.Callable[[traits.Context], typing.Awaitable[typing.Iterable[str]]]
-        ] = None
         self._rest = rest
         self._shards = shard
 
@@ -179,6 +178,10 @@ class Client(traits.Client):
     @property
     def metadata(self) -> typing.MutableMapping[typing.Any, typing.Any]:
         return self._metadata
+
+    @property
+    def prefix_getter(self) -> typing.Optional[PrefixGetterT]:
+        return self._prefix_getter
 
     @property
     def prefixes(self) -> typing.AbstractSet[str]:
@@ -231,11 +234,7 @@ class Client(traits.Client):
 
         return self
 
-    def set_prefix_getter(
-        self: ClientT,
-        getter: typing.Optional[typing.Callable[[traits.Context], typing.Awaitable[typing.Iterable[str]]]],
-        /,
-    ) -> ClientT:
+    def set_prefix_getter(self: ClientT, getter: typing.Optional[PrefixGetterT], /) -> ClientT:
         self._prefix_getter = getter
         return self
 

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -56,7 +56,7 @@ if typing.TYPE_CHECKING:
 
     from hikari import users
 
-    ClientT = typing.TypeVar("ClientT", bound="Client")
+    _ClientT = typing.TypeVar("_ClientT", bound="Client")
 
 
 PrefixGetterT = typing.Callable[[traits.Context], typing.Awaitable[typing.Iterable[str]]]
@@ -177,7 +177,7 @@ class Client(traits.Client):
         if event_managed:
             self._events.event_manager.subscribe(lifetime_events.StartingEvent, self._on_starting_event)
             self._events.event_manager.subscribe(lifetime_events.StoppingEvent, self._on_stopping_event)
-        self.set_human_only()
+        self.set_human_only(True)
 
     async def __aenter__(self) -> Client:
         await self.open()
@@ -246,11 +246,11 @@ class Client(traits.Client):
     async def _on_stopping_event(self, _: lifetime_events.StoppingEvent, /) -> None:
         await self.close()
 
-    def set_accepts(self: ClientT, accepts: AcceptsEnum, /) -> ClientT:
+    def set_accepts(self: _ClientT, accepts: AcceptsEnum, /) -> _ClientT:
         self._accepts = accepts
         return self
 
-    def set_human_only(self: ClientT, value: bool = True) -> ClientT:
+    def set_human_only(self: _ClientT, value: bool = True) -> _ClientT:
         if value:
             self._checks.add(_check_human)
 
@@ -262,7 +262,7 @@ class Client(traits.Client):
 
         return self
 
-    def add_check(self: ClientT, check: traits.CheckT, /) -> ClientT:
+    def add_check(self: _ClientT, check: traits.CheckT, /) -> _ClientT:
         self._checks.add(check)
         return self
 
@@ -276,14 +276,14 @@ class Client(traits.Client):
     async def check(self, ctx: traits.Context, /) -> bool:
         return await utilities.gather_checks(utilities.await_if_async(check, ctx) for check in self._checks)
 
-    def add_component(self: ClientT, component: traits.Component, /) -> ClientT:
+    def add_component(self: _ClientT, component: traits.Component, /) -> _ClientT:
         self._components.add(component)
         return self
 
     def remove_component(self, component: traits.Component, /) -> None:
         self._components.remove(component)
 
-    def add_prefix(self: ClientT, prefixes: typing.Union[typing.Iterable[str], str], /) -> ClientT:
+    def add_prefix(self: _ClientT, prefixes: typing.Union[typing.Iterable[str], str], /) -> _ClientT:
         if isinstance(prefixes, str):
             self._prefixes.add(prefixes)
 
@@ -295,7 +295,7 @@ class Client(traits.Client):
     def remove_prefix(self, prefix: str, /) -> None:
         self._prefixes.remove(prefix)
 
-    def set_prefix_getter(self: ClientT, getter: typing.Optional[PrefixGetterT], /) -> ClientT:
+    def set_prefix_getter(self: _ClientT, getter: typing.Optional[PrefixGetterT], /) -> _ClientT:
         self._prefix_getter = getter
         return self
 
@@ -363,11 +363,11 @@ class Client(traits.Client):
         if register_listener and event_type:
             self._events.event_manager.subscribe(event_type, self.on_message_create)
 
-    def set_hooks(self: ClientT, hooks: typing.Optional[traits.Hooks], /) -> ClientT:
+    def set_hooks(self: _ClientT, hooks: typing.Optional[traits.Hooks], /) -> _ClientT:
         self.hooks = hooks
         return self
 
-    def load_modules(self: ClientT, modules: typing.Iterable[typing.Union[str, pathlib.Path]], /) -> ClientT:
+    def load_modules(self: _ClientT, modules: typing.Iterable[typing.Union[str, pathlib.Path]], /) -> _ClientT:
         for module_path in modules:
             if isinstance(module_path, str):
                 module = importlib.import_module(module_path)

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -349,8 +349,8 @@ class Client(traits.Client):
             except (ValueError, LookupError):
                 pass
 
-    async def open(self, *, mention_prefix: bool = True, register_listener: bool = True) -> None:
-        if mention_prefix:
+    async def open(self, *, get_mention_prefix: bool = False, register_listener: bool = True) -> None:
+        if get_mention_prefix:
             user: typing.Optional[users.User] = None
             if self._cache:
                 user = self._cache.cache.get_me()

--- a/tanjun/commands.py
+++ b/tanjun/commands.py
@@ -111,17 +111,14 @@ class Command(traits.ExecutableCommand):
         return frozenset(self._names)
 
     def add_check(self: CommandT, check: traits.CheckT, /) -> CommandT:
-        self.add_check(check)
-        return self
-
-    def append_check(self, check: traits.CheckT, /) -> None:
         self._checks.add(check)
+        return self
 
     def remove_check(self, check: traits.CheckT, /) -> None:
         self._checks.remove(check)
 
     def with_check(self, check: traits.CheckT, /) -> traits.CheckT:
-        self.append_check(check)
+        self.add_check(check)
         return check
 
     async def check_context(
@@ -132,11 +129,8 @@ class Command(traits.ExecutableCommand):
                 yield found
 
     def add_name(self: CommandT, name: str, /) -> CommandT:
-        self.append_name(name)
-        return self
-
-    def append_name(self, name: str, /) -> None:
         self._names.add(name)
+        return self
 
     def check_name(self, name: str, /) -> typing.Iterator[traits.FoundCommand]:
         for own_name in self._names:
@@ -242,16 +236,13 @@ class CommandGroup(Command, traits.ExecutableCommandGroup):
         return frozenset(self._commands)
 
     def add_command(self: CommandGroupT, command: traits.ExecutableCommand, /) -> CommandGroupT:
-        self.append_command(command)
-        return self
-
-    def append_command(self, command: traits.ExecutableCommand, /) -> None:
         command.parent = self
         self._commands.add(command)
+        return self
 
     def remove_command(self, command: traits.ExecutableCommand, /) -> None:
-        command.parent = None
         self._commands.remove(command)
+        command.parent = None
 
     def with_command(
         self,

--- a/tanjun/commands.py
+++ b/tanjun/commands.py
@@ -43,8 +43,9 @@ from tanjun import hooks as hooks_
 from tanjun import traits
 from tanjun import utilities
 
-CommandT = typing.TypeVar("CommandT", bound="Command")
-CommandGroupT = typing.TypeVar("CommandGroupT", bound="CommandGroup")
+if typing.TYPE_CHECKING:
+    _CommandT = typing.TypeVar("_CommandT", bound="Command")
+    _CommandGroupT = typing.TypeVar("_CommandGroupT", bound="CommandGroup")
 
 
 class FoundCommand(traits.FoundCommand):
@@ -110,7 +111,7 @@ class Command(traits.ExecutableCommand):
     def names(self) -> typing.AbstractSet[str]:
         return frozenset(self._names)
 
-    def add_check(self: CommandT, check: traits.CheckT, /) -> CommandT:
+    def add_check(self: _CommandT, check: traits.CheckT, /) -> _CommandT:
         self._checks.add(check)
         return self
 
@@ -128,7 +129,7 @@ class Command(traits.ExecutableCommand):
             if await utilities.gather_checks(utilities.await_if_async(check, ctx) for check in self._checks):
                 yield found
 
-    def add_name(self: CommandT, name: str, /) -> CommandT:
+    def add_name(self: _CommandT, name: str, /) -> _CommandT:
         self._names.add(name)
         return self
 
@@ -235,7 +236,7 @@ class CommandGroup(Command, traits.ExecutableCommandGroup):
     def commands(self) -> typing.AbstractSet[traits.ExecutableCommand]:
         return frozenset(self._commands)
 
-    def add_command(self: CommandGroupT, command: traits.ExecutableCommand, /) -> CommandGroupT:
+    def add_command(self: _CommandGroupT, command: traits.ExecutableCommand, /) -> _CommandGroupT:
         command.parent = self
         self._commands.add(command)
         return self

--- a/tanjun/components.py
+++ b/tanjun/components.py
@@ -49,7 +49,7 @@ if typing.TYPE_CHECKING:
     from hikari.api import event_manager
 
     _CommandDescriptorT = typing.TypeVar("_CommandDescriptorT", bound="CommandDescriptor")
-    _CommandT = typing.TypeVar("_CommandT", "traits.ExecutableCommand", traits.CommandDescriptor)
+    _CommandT = typing.TypeVar("_CommandT", traits.ExecutableCommand, traits.CommandDescriptor)
     ComponentT = typing.TypeVar("ComponentT", bound="Component")
     _ValueT = typing.TypeVar("_ValueT")
 

--- a/tanjun/components.py
+++ b/tanjun/components.py
@@ -48,10 +48,10 @@ from tanjun import utilities
 if typing.TYPE_CHECKING:
     from hikari.api import event_manager
 
-    CommandDescriptorT = typing.TypeVar("CommandDescriptorT", bound="CommandDescriptor")
-    CommandT = typing.TypeVar("CommandT", "traits.ExecutableCommand", traits.CommandDescriptor)
+    _CommandDescriptorT = typing.TypeVar("_CommandDescriptorT", bound="CommandDescriptor")
+    _CommandT = typing.TypeVar("_CommandT", "traits.ExecutableCommand", traits.CommandDescriptor)
     ComponentT = typing.TypeVar("ComponentT", bound="Component")
-    ValueT = typing.TypeVar("ValueT")
+    _ValueT = typing.TypeVar("_ValueT")
 
 
 # This class is left unslotted as to allow it to "wrap" the underlying function
@@ -118,7 +118,7 @@ class CommandDescriptor(traits.CommandDescriptor):
     def parser(self, parser_: typing.Optional[traits.ParserDescriptor]) -> None:
         self._parser = parser_
 
-    def add_check(self: CommandDescriptorT, check: traits.CheckT, /) -> CommandDescriptorT:
+    def add_check(self: _CommandDescriptorT, check: traits.CheckT, /) -> _CommandDescriptorT:
         self._checks.append(check)
         return self
 
@@ -126,7 +126,7 @@ class CommandDescriptor(traits.CommandDescriptor):
         self._unbound_checks.append(check)
         return check
 
-    def add_name(self: CommandDescriptorT, name: str, /) -> CommandDescriptorT:
+    def add_name(self: _CommandDescriptorT, name: str, /) -> _CommandDescriptorT:
         self._names.append(name)
         return self
 
@@ -534,7 +534,7 @@ class Component(traits.Component):
     def remove_command(self, command: traits.ExecutableCommand, /) -> None:
         self._commands.remove(command)
 
-    def with_command(self, command: CommandT, /) -> CommandT:
+    def with_command(self, command: _CommandT, /) -> _CommandT:
         self.add_command(command)
         return command
 
@@ -558,8 +558,8 @@ class Component(traits.Component):
 
     def with_listener(
         self, event: typing.Type[base_events.Event], /
-    ) -> typing.Callable[[event_manager.CallbackT[ValueT]], event_manager.CallbackT[ValueT]]:
-        def decorator(callback: event_manager.CallbackT[ValueT], /) -> event_manager.CallbackT[ValueT]:
+    ) -> typing.Callable[[event_manager.CallbackT[_ValueT]], event_manager.CallbackT[_ValueT]]:
+        def decorator(callback: event_manager.CallbackT[_ValueT], /) -> event_manager.CallbackT[_ValueT]:
             self.add_listener(event, callback)
             return callback
 

--- a/tanjun/context.py
+++ b/tanjun/context.py
@@ -55,7 +55,7 @@ class Context(traits.Context):
         "_message",
         "_rest",
         "triggering_name",
-        "triggering_prefix",
+        "_triggering_prefix",
         "_shard",
     )
 
@@ -67,8 +67,8 @@ class Context(traits.Context):
         message: messages.Message,
         *,
         command: typing.Optional[traits.ExecutableCommand] = None,
-        triggering_name: typing.Optional[str] = None,
-        triggering_prefix: typing.Optional[str] = None,
+        triggering_name: str = "",
+        triggering_prefix: str = "",
     ) -> None:
         if message.content is None:
             raise ValueError("Cannot spawn context with a contentless message.")
@@ -78,7 +78,7 @@ class Context(traits.Context):
         self.content = content
         self._message = message
         self.triggering_name = triggering_name
-        self.triggering_prefix = triggering_prefix
+        self._triggering_prefix = triggering_prefix
 
     def __repr__(self) -> str:
         return f"Context <{self.message!r}, {self.command!r}>"
@@ -98,6 +98,16 @@ class Context(traits.Context):
     @property
     def message(self) -> messages.Message:
         return self._message
+
+    @property
+    def triggering_prefix(self) -> str:
+        return self._triggering_prefix
+
+    # Since this isn't settable on the interface we need to override this with a property
+    # rather than just using a slotted instance variable.
+    @triggering_prefix.setter
+    def triggering_prefix(self, triggering_prefix: str) -> None:
+        self._triggering_prefix = triggering_prefix
 
     @property
     def rest_service(self) -> hikari_traits.RESTAware:

--- a/tanjun/traits.py
+++ b/tanjun/traits.py
@@ -828,12 +828,6 @@ class Client(typing.Protocol):
     def remove_component(self, component: Component, /) -> None:
         raise NotImplementedError
 
-    def add_prefix(self, prefix: str, /) -> None:
-        raise NotImplementedError
-
-    def remove_prefix(self, prefix: str, /) -> None:
-        raise NotImplementedError
-
     # As far as MYPY is concerned, unless you explicitly yield within an async function typed as returning an
     # AsyncIterator/AsyncGenerator you are returning an AsyncIterator/AsyncGenerator as the result of a coroutine.
     def check_context(self, ctx: Context, /) -> typing.AsyncIterator[FoundCommand]:

--- a/tanjun/traits.py
+++ b/tanjun/traits.py
@@ -275,7 +275,7 @@ class CommandDescriptor(typing.Protocol):
     def parser(self, parser: ParserDescriptor, /) -> None:
         raise NotImplementedError
 
-    def add_check(self, check: CheckT, /) -> None:
+    def append_check(self, check: CheckT, /) -> None:
         """Add a pre-execution check for this command descriptor.
 
         This will be run before execution to decide whether the command should
@@ -313,7 +313,7 @@ class CommandDescriptor(typing.Protocol):
         """
         raise NotImplementedError
 
-    def add_name(self, name: str, /) -> None:
+    def append_name(self, name: str, /) -> None:
         """Add a execution name to this command.
 
         This name is used to decide whether the command fits a given string or
@@ -614,7 +614,7 @@ class Executable(typing.Protocol):
     def hooks(self, hooks: typing.Optional[Hooks]) -> None:
         raise NotImplementedError
 
-    def add_check(self, check: CheckT, /) -> None:
+    def append_check(self, check: CheckT, /) -> None:
         raise NotImplementedError
 
     def remove_check(self, check: CheckT, /) -> None:
@@ -692,7 +692,7 @@ class ExecutableCommand(Executable, typing.Protocol):
     def parser(self, parser: typing.Optional[Parser], /) -> None:
         raise NotImplementedError
 
-    def add_name(self, name: str, /) -> None:
+    def append_name(self, name: str, /) -> None:
         raise NotImplementedError
 
     def remove_name(self, name: str, /) -> None:
@@ -712,7 +712,7 @@ class ExecutableCommandGroup(ExecutableCommand, typing.Protocol):
     def commands(self) -> typing.AbstractSet[ExecutableCommand]:
         raise NotImplementedError
 
-    def add_command(self, command: ExecutableCommand, /) -> None:
+    def append_command(self, command: ExecutableCommand, /) -> None:
         raise NotImplementedError
 
     def remove_command(self, command: ExecutableCommand, /) -> None:
@@ -752,13 +752,13 @@ class Component(Executable, typing.Protocol):
     def metadata(self) -> typing.MutableMapping[typing.Any, typing.Any]:
         raise NotImplementedError
 
-    def add_command(self, command: ExecutableCommand, /) -> None:
+    def append_command(self, command: ExecutableCommand, /) -> None:
         raise NotImplementedError
 
     def remove_command(self, command: ExecutableCommand, /) -> None:
         raise NotImplementedError
 
-    def add_listener(
+    def append_listener(
         self, event: typing.Type[base_events.Event], listener: event_manager.CallbackT[typing.Any], /
     ) -> None:
         raise NotImplementedError
@@ -818,7 +818,7 @@ class Client(typing.Protocol):
     def shard_service(self) -> traits.ShardAware:
         raise NotImplementedError
 
-    def add_component(self, component: Component, /) -> None:
+    def append_component(self, component: Component, /) -> None:
         raise NotImplementedError
 
     def remove_component(self, component: Component, /) -> None:

--- a/tanjun/traits.py
+++ b/tanjun/traits.py
@@ -489,7 +489,7 @@ class Context(typing.Protocol):
         """
         raise NotImplementedError
 
-    @property
+    @property  # TODO: can we somehow have this always be present on the command execution facing interface
     def command(self) -> typing.Optional[ExecutableCommand]:
         raise NotImplementedError
 
@@ -526,15 +526,11 @@ class Context(typing.Protocol):
         raise NotImplementedError
 
     @property
-    def triggering_prefix(self) -> typing.Optional[str]:
-        raise NotImplementedError
-
-    @triggering_prefix.setter
-    def triggering_prefix(self, triggering_prefix: str, /) -> None:
+    def triggering_prefix(self) -> str:
         raise NotImplementedError
 
     @property
-    def triggering_name(self) -> typing.Optional[str]:
+    def triggering_name(self) -> str:
         raise NotImplementedError
 
     @triggering_name.setter

--- a/tanjun/traits.py
+++ b/tanjun/traits.py
@@ -44,7 +44,7 @@ __all__: typing.Sequence[str] = [
     "HookT",
     "PreExecutionHookT",
     "CheckT",
-    "ValueT",
+    "ValueT_co",
     "Context",
     "Converter",
     "StatelessConverter",
@@ -72,6 +72,8 @@ if typing.TYPE_CHECKING:
     from hikari.events import base_events
 
     from tanjun import errors
+
+    _T = typing.TypeVar("_T")
 
 
 # To allow for stateless converters we accept both "Converter[...]" and "Type[StatelessConverter[...]]" where all the
@@ -175,7 +177,7 @@ This is an equivalent to `CheckT` where it's yet to be bound to a `Component`,
 used by `CheckDescriptor`.
 """
 
-ValueT = typing.TypeVar("ValueT", covariant=True)
+ValueT_co = typing.TypeVar("ValueT_co", covariant=True)
 """A general type hint used for generic interfaces in Tanjun."""
 
 
@@ -275,7 +277,7 @@ class CommandDescriptor(typing.Protocol):
     def parser(self, parser: ParserDescriptor, /) -> None:
         raise NotImplementedError
 
-    def append_check(self, check: CheckT, /) -> None:
+    def add_check(self: _T, check: CheckT, /) -> _T:
         """Add a pre-execution check for this command descriptor.
 
         This will be run before execution to decide whether the command should
@@ -313,7 +315,7 @@ class CommandDescriptor(typing.Protocol):
         """
         raise NotImplementedError
 
-    def append_name(self, name: str, /) -> None:
+    def add_name(self: _T, name: str, /) -> _T:
         """Add a execution name to this command.
 
         This name is used to decide whether the command fits a given string or
@@ -539,10 +541,10 @@ class Context(typing.Protocol):
 
 
 @typing.runtime_checkable
-class Converter(typing.Protocol[ValueT]):
+class Converter(typing.Protocol[ValueT_co]):
     __slots__: typing.Sequence[str] = ()
 
-    async def convert(self, ctx: Context, argument: str, /) -> ValueT:
+    async def convert(self, ctx: Context, argument: str, /) -> ValueT_co:
         raise NotImplementedError
 
     def bind_client(self, client: Client, /) -> None:
@@ -553,11 +555,11 @@ class Converter(typing.Protocol[ValueT]):
 
 
 @typing.runtime_checkable
-class StatelessConverter(typing.Protocol[ValueT]):
+class StatelessConverter(typing.Protocol[ValueT_co]):
     __slots__: typing.Sequence[str] = ()
 
     @classmethod
-    async def convert(cls, ctx: Context, argument: str, /) -> ValueT:
+    async def convert(cls, ctx: Context, argument: str, /) -> ValueT_co:
         raise NotImplementedError
 
     @classmethod
@@ -614,7 +616,7 @@ class Executable(typing.Protocol):
     def hooks(self, hooks: typing.Optional[Hooks]) -> None:
         raise NotImplementedError
 
-    def append_check(self, check: CheckT, /) -> None:
+    def add_check(self: _T, check: CheckT, /) -> _T:
         raise NotImplementedError
 
     def remove_check(self, check: CheckT, /) -> None:
@@ -692,7 +694,7 @@ class ExecutableCommand(Executable, typing.Protocol):
     def parser(self, parser: typing.Optional[Parser], /) -> None:
         raise NotImplementedError
 
-    def append_name(self, name: str, /) -> None:
+    def add_name(self: _T, name: str, /) -> _T:
         raise NotImplementedError
 
     def remove_name(self, name: str, /) -> None:
@@ -712,7 +714,7 @@ class ExecutableCommandGroup(ExecutableCommand, typing.Protocol):
     def commands(self) -> typing.AbstractSet[ExecutableCommand]:
         raise NotImplementedError
 
-    def append_command(self, command: ExecutableCommand, /) -> None:
+    def add_command(self: _T, command: ExecutableCommand, /) -> _T:
         raise NotImplementedError
 
     def remove_command(self, command: ExecutableCommand, /) -> None:
@@ -752,15 +754,15 @@ class Component(Executable, typing.Protocol):
     def metadata(self) -> typing.MutableMapping[typing.Any, typing.Any]:
         raise NotImplementedError
 
-    def append_command(self, command: ExecutableCommand, /) -> None:
+    def add_command(self: _T, command: ExecutableCommand, /) -> _T:
         raise NotImplementedError
 
     def remove_command(self, command: ExecutableCommand, /) -> None:
         raise NotImplementedError
 
-    def append_listener(
-        self, event: typing.Type[base_events.Event], listener: event_manager.CallbackT[typing.Any], /
-    ) -> None:
+    def add_listener(
+        self: _T, event: typing.Type[base_events.Event], listener: event_manager.CallbackT[typing.Any], /
+    ) -> _T:
         raise NotImplementedError
 
     def remove_listener(
@@ -818,7 +820,7 @@ class Client(typing.Protocol):
     def shard_service(self) -> traits.ShardAware:
         raise NotImplementedError
 
-    def append_component(self, component: Component, /) -> None:
+    def add_component(self: _T, component: Component, /) -> _T:
         raise NotImplementedError
 
     def remove_component(self, component: Component, /) -> None:


### PR DESCRIPTION
This change adds prefix getter to the main Client implementation. Closes: #8 

Other changes in this include:
* Remove prefix methods from `traits.Client`
* Prefer builder pattern over optional keyword argument in standard Client implementation
* `Client.check_prefix` -> `Client._check_prefix`