### PR TITLE
Fix wrong default `error_message` in checkers docs.

### DIFF
--- a/tanjun/checks.py
+++ b/tanjun/checks.py
@@ -485,7 +485,7 @@ def with_guild_check(
     error_message : typing.Optional[str]
         The error message to send in response as a command error if the check fails.
 
-        Defaults to "Command can only be used in DMs" and setting this to `None`
+        Defaults to "Command can only be used in guild channels" and setting this to `None`
         will disable the error message allowing the command search to continue.
     halt_execution : bool
         Whether this check should raise `tanjun.errors.HaltExecution` to
@@ -538,7 +538,7 @@ def with_nsfw_check(
     error_message : typing.Optional[str]
         The error message to send in response as a command error if the check fails.
 
-        Defaults to "Command can only be used in DMs" and setting this to `None`
+        Defaults to "Command can only be used in NSFW channels" and setting this to `None`
         will disable the error message allowing the command search to continue.
     halt_execution : bool
         Whether this check should raise `tanjun.errors.HaltExecution` to
@@ -593,7 +593,7 @@ def with_sfw_check(
     error_message : typing.Optional[str]
         The error message to send in response as a command error if the check fails.
 
-        Defaults to "Command can only be used in DMs" and setting this to `None`
+        Defaults to "Command can only be used in SFW channels" and setting this to `None`
         will disable the error message allowing the command search to continue.
     halt_execution : bool
         Whether this check should raise `tanjun.errors.HaltExecution` to
@@ -652,7 +652,7 @@ def with_owner_check(
     error_message : typing.Optional[str]
         The error message to send in response as a command error if the check fails.
 
-        Defaults to "Command can only be used in DMs" and setting this to `None`
+        Defaults to "Only bot owners can use this command" and setting this to `None`
         will disable the error message allowing the command search to continue.
     expire_delta: datetime.timedelta
         How long cached application owner data should be cached for.
@@ -707,7 +707,7 @@ def with_author_permission_check(
     error_message : typing.Optional[str]
         The error message to send in response as a command error if the check fails.
 
-        Defaults to "Command can only be used in DMs" and setting this to `None`
+        Defaults to "You don't have the permissions required to use this command" and setting this to `None`
         will disable the error message allowing the command search to continue.
     halt_execution : bool
         Whether this check should raise `tanjun.errors.HaltExecution` to
@@ -749,7 +749,7 @@ def with_own_permission_check(
     error_message : typing.Optional[str]
         The error message to send in response as a command error if the check fails.
 
-        Defaults to "Command can only be used in DMs" and setting this to `None`
+        Defaults to "Bot doesn't have the permissions required to run this command" and setting this to `None`
         will disable the error message allowing the command search to continue.
     halt_execution : bool
         Whether this check should raise `tanjun.errors.HaltExecution` to


### PR DESCRIPTION
PR Fixes some default `error_message` in checkers docstrings while going through the docs.