### PR TITLE
Always default to False for boolean slash command options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow for overriding the standard client's context builders.
 - Add default_permission argument to slash command types.
 
+### Fixed
+- Now handle when Discord doesn't include boolean options in interaction payloads because they were passed as `False`
+  and weight reduction bro.
+- Doc typo and export fixes.
+
 ## [2.0.0a1] - 2021-08-30
 ### Added
 - For a TLDR of how Tanjun's interface looks after these changes see the examples


### PR DESCRIPTION
Discord just won't include required boolean options in the event they send if it was passed as False cause why not