### PR TITLE
Add SlashContext.options mapping + rely on this while forming kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add `always_float` keyword argument to with_float_slash_option.
+- SlashContext.options mapping plus a resolvable option type to allow for more easily getting slash command
+  options without relying on passed keyword arguments.
 
 ### Changed
 - Renamed `Client.__init__` "shard" arg to "shards".
+- Annotate implimation functions/properties which return collections as returning `collections.abc.Collection`
+  instead of their implemation specific subclass of Collcetion.
 
 ### Fixed
 - Edit the command if command_id is passed to declare_slash_command instead of creating a new command.

--- a/tanjun/__init__.py
+++ b/tanjun/__init__.py
@@ -150,6 +150,7 @@ __all__: list[str] = [
     "context",
     "MessageContext",
     "SlashContext",
+    "SlashOption",
     # conversion.py
     "conversion",
     "to_channel",

--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -55,6 +55,7 @@ __all__: list[str] = [
     "SlashCommand",
     "SlashCommandGroup",
     "SlashContext",
+    "SlashOption",
     "Component",
     "Client",
 ]
@@ -592,7 +593,184 @@ class MessageContext(Context, abc.ABC):
         raise NotImplementedError
 
 
+class SlashOption(abc.ABC):
+    """Interface of slash command option with extra logic to help resolve it."""
+
+    __slots__ = ()
+
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
+        """Name of this option."""
+
+    @property
+    @abc.abstractmethod
+    def type(self) -> typing.Union[hikari.OptionType, int]:
+        """Type of this option."""
+
+    @property
+    @abc.abstractmethod
+    def value(self) -> typing.Union[str, int, bool, float]:
+        """Value provided for this option.
+
+        .. note::
+            For discord entity option types (e.g. user, member, channel and
+            role) this will be the entity's ID.
+
+        Returns
+        -------
+        typing.Union[str, int, bool, float]
+            The value provided for this option.
+        """
+
+    @abc.abstractmethod
+    def resolve_value(
+        self,
+    ) -> typing.Union[hikari.InteractionChannel, hikari.InteractionMember, hikari.Role, hikari.User]:
+        """Resolve this option to an object value.
+
+        Other Parameters
+        ----------------
+        default:
+            The default value to return if this option cannot be resolved.
+
+            If this is not provided, this method will raise a `TypeError` if
+            this option cannot be resolved.
+
+        Returns
+        -------
+        typing.Union[hikari.InteractionChannel, hikari.InteractionMember, hikari.Role, hikari.User]
+            The object value of this option.
+
+        Raises
+        ------
+        TypeError
+            If the option isn't resolvable.
+        """
+
+    @abc.abstractmethod
+    def resolve_to_channel(self) -> hikari.InteractionChannel:
+        """Resolve this option to a channel object.
+
+        Returns
+        -------
+        hikari.InteractionChannel
+            The channel object.
+
+        Raises
+        ------
+        TypeError
+            If the option is not a channel and a `default` wasn't provided.
+        """
+
+    @typing.overload
+    @abc.abstractmethod
+    def resolve_to_member(self) -> hikari.InteractionMember:
+        ...
+
+    @typing.overload
+    @abc.abstractmethod
+    def resolve_to_member(self, *, default: _T) -> typing.Union[hikari.InteractionMember, _T]:
+        ...
+
+    @abc.abstractmethod
+    def resolve_to_member(self, *, default: _T = ...) -> typing.Union[hikari.InteractionMember, _T]:
+        """Resolve this option to a member object.
+
+        Other Parameters
+        ----------------
+        default:
+            The default value to return if this option cannot be resolved.
+
+            If this is not provided, this method will raise a `TypeError` if
+            this option cannot be resolved.
+
+        Returns
+        -------
+        typing.Union[hikari.InteractionMember, _T]
+            The member object or `default` if it was provided and this option
+            was a user type but had no member.
+
+        Raises
+        ------
+        LookupError
+            If no member was found for this option and a `default` wasn't provided.
+
+            This includes if the option is a mentionable type which targets a
+            member-less user.
+
+            This could happen if the user isn't in the current guild or if this
+            command was executed in a DM and this option should still be resolvable
+            to a user.
+        TypeError
+            If the option is not a user option and a `default` wasn't provided.
+
+            This includes if the option is a mentionable type but doesn't
+            target a user.
+        """
+
+    @abc.abstractmethod
+    def resolve_to_mentionable(self) -> typing.Union[hikari.Role, hikari.User, hikari.Member]:
+        """Resolve this option to a mentionable object.
+
+        Returns
+        -------
+        typing.Union[hikari.Role, hikari.User, hikari.Member]
+            The mentionable object.
+
+        Raises
+        ------
+        TypeError
+            If the option is not a mentionable, user or role type.
+        """
+
+    @abc.abstractmethod
+    def resolve_to_role(self) -> hikari.Role:
+        """Resolve this option to a role object.
+
+        Returns
+        -------
+        hikari.Role
+            The role object.
+
+        Raises
+        ------
+        TypeError
+            If the option is not a role.
+
+            This includes mentionable options which point towards a user.
+        """
+
+    @abc.abstractmethod
+    def resolve_to_user(self) -> typing.Union[hikari.User, hikari.Member]:
+        """Resolve this option to a user object.
+
+        .. note::
+            This will resolve to a `hikari.Member` first if the relevant
+            command was executed within a guild and the option targeted one of
+            the guild's members, otherwise it will resolve to `hikari.User`.
+
+            It's also worth noting that hikari.Member inherits from hikari.User
+            meaning that the return value of this can always be treated as a
+            user.
+
+        Returns
+        -------
+        typing.Union[hikari.User, hikari.Member]
+            The user object.
+
+        Raises
+        ------
+        TypeError
+            If the option is not a user.
+
+            This includes mentionable options which point towards a role.
+        """
+
+
 class SlashContext(Context, abc.ABC):
+    """Interface of a slash command specific context."""
+
     __slots__ = ()
 
     @property
@@ -663,6 +841,17 @@ class SlashContext(Context, abc.ABC):
         -------
         typing.Optional[hikari.InteractionMember]
             The member that triggered this command if this is in a guild.
+        """
+
+    @property
+    @abc.abstractmethod
+    def options(self) -> collections.Mapping[str, SlashOption]:
+        """Return a mapping of option names to the values provided for them.
+
+        Returns
+        -------
+        collections.abc.Mapping[str, SlashOption]
+            Mapping of option names to their values.
         """
 
     @abc.abstractmethod

--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -629,14 +629,6 @@ class SlashOption(abc.ABC):
     ) -> typing.Union[hikari.InteractionChannel, hikari.InteractionMember, hikari.Role, hikari.User]:
         """Resolve this option to an object value.
 
-        Other Parameters
-        ----------------
-        default:
-            The default value to return if this option cannot be resolved.
-
-            If this is not provided, this method will raise a `TypeError` if
-            this option cannot be resolved.
-
         Returns
         -------
         typing.Union[hikari.InteractionChannel, hikari.InteractionMember, hikari.Role, hikari.User]

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -608,13 +608,13 @@ class Client(injecting.InjectorClient, tanjun_abc.Client):
         return self._cache
 
     @property
-    def checks(self) -> collections.Set[tanjun_abc.CheckSig]:
-        """Set of the top level `tanjun.abc.Context` checks registered to this client.
+    def checks(self) -> collections.Collection[tanjun_abc.CheckSig]:
+        """Return a collcetion of the level `tanjun.abc.Context` checks registered to this client.
 
         Returns
         -------
         collections.abc.Set[tanjun.abc.CheckSig]
-            Set of the `tanjun.abc.Context` based checks registered for
+            Colleciton of the `tanjun.abc.Context` based checks registered for
             this client.
 
             These may be taking advantage of the standard dependency injection.
@@ -622,7 +622,7 @@ class Client(injecting.InjectorClient, tanjun_abc.Client):
         return {check.callback for check in self._checks}
 
     @property
-    def components(self) -> collections.Set[tanjun_abc.Component]:
+    def components(self) -> collections.Collection[tanjun_abc.Component]:
         # <<inherited docstring from tanjun.abc.Client>>.
         return self._components.copy()
 

--- a/tanjun/commands.py
+++ b/tanjun/commands.py
@@ -132,7 +132,7 @@ class PartialCommand(abc.ExecutableCommand[abc.ContextT]):
         self._metadata = dict(metadata) if metadata else {}
 
     @property
-    def checks(self) -> collections.Set[abc.CheckSig]:
+    def checks(self) -> collections.Collection[abc.CheckSig]:
         # <<inherited docstring from tanjun.abc.ExecutableCommand>>.
         return {check.callback for check in self._checks}
 
@@ -1079,7 +1079,7 @@ class SlashCommandGroup(BaseSlashCommand, abc.SlashCommandGroup):
         self._default_permission = default_permission
 
     @property
-    def commands(self) -> collections.ValuesView[abc.BaseSlashCommand]:
+    def commands(self) -> collections.Collection[abc.BaseSlashCommand]:
         # <<inherited docstring from tanjun.abc.SlashCommandGroup>>.
         return self._commands.copy().values()
 
@@ -1311,61 +1311,50 @@ class SlashCommand(BaseSlashCommand, abc.SlashCommand, typing.Generic[CommandCal
             )
         return self
 
-    async def _process_args(
-        self,
-        ctx: abc.SlashContext,
-        options: collections.Iterable[hikari.CommandInteractionOption],
-        option_data: hikari.ResolvedOptionData,
-        /,
-    ) -> dict[str, typing.Any]:
-        keyword_args: dict[str, typing.Any] = {}
-        options_dict = {option.name: option for option in options}
-        for tracked_option in self._tracked_options.values():
-            option = options_dict.get(tracked_option.name)
-            if not option or not option.value:
-                if tracked_option.default is _UNDEFINED_DEFAULT:
-                    if tracked_option.type is not hikari.OptionType.BOOLEAN:
-                        raise RuntimeError(  # TODO: ConversionError?
-                            f"Required option {tracked_option.name} is missing data, are you sure your commands"
-                            " are up to date?"
-                        )
+    async def _process_args(self, ctx: abc.SlashContext, /) -> collections.Mapping[str, typing.Any]:
+        if not self._tracked_options:
+            return _EMPTY_DICT
 
-                    # If a required boolean field is passed as False then Discord just won't include the option in the
-                    # interaction event cause payload size reduction so we have to always default to False.
-                    keyword_args[tracked_option.name] = False
+        keyword_args: dict[str, typing.Union[int, float, str, hikari.User, hikari.Role, hikari.InteractionChannel]] = {}
+        for tracked_option in self._tracked_options.values():
+            # TODO: investigate difference between not present and None
+            if not (option := ctx.options.get(tracked_option.name)):
+                if tracked_option.default is _UNDEFINED_DEFAULT:
+                    raise RuntimeError(  # TODO: ConversionError?
+                        f"Required option {tracked_option.name} is missing data, are you sure your commands"
+                        " are up to date?"
+                    )
 
                 else:
                     keyword_args[tracked_option.name] = tracked_option.default
 
             elif option.type is hikari.OptionType.USER:
-                user_id = hikari.Snowflake(option.value)
-                member = option_data.members.get(user_id)
-                if not member and tracked_option.is_only_member:
+                member: typing.Optional[hikari.InteractionMember] = None
+                if tracked_option.is_only_member and not (member := option.resolve_to_member(default=None)):
                     raise errors.ConversionError(
-                        tracked_option.name, f"Couldn't find member for provided user: {user_id}"
+                        tracked_option.name, f"Couldn't find member for provided user: {option.value}"
                     )
 
-                keyword_args[option.name] = member or option_data.users[user_id]
+                keyword_args[option.name] = member or option.resolve_to_user()
 
             elif option.type is hikari.OptionType.CHANNEL:
-                keyword_args[option.name] = option_data.channels[hikari.Snowflake(option.value)]
+                keyword_args[option.name] = option.resolve_to_channel()
 
             elif option.type is hikari.OptionType.ROLE:
-                keyword_args[option.name] = option_data.roles[hikari.Snowflake(option.value)]
+                keyword_args[option.name] = option.resolve_to_role()
 
             elif option.type is hikari.OptionType.MENTIONABLE:
-                id_ = hikari.Snowflake(option.value)
-                if role := option_data.roles.get(id_):
-                    keyword_args[option.name] = role
+                if option.type is hikari.OptionType.ROLE:
+                    keyword_args[option.name] = option.resolve_to_role()
 
                 else:
-                    member = option_data.members.get(id_)
-                    if not member and tracked_option.is_only_member:
+                    member: typing.Optional[hikari.InteractionMember] = None
+                    if tracked_option.is_only_member and not (member := option.resolve_to_member()):
                         raise errors.ConversionError(
-                            tracked_option.name, f"Couldn't find member for provided user: {id_}"
+                            tracked_option.name, f"Couldn't find member for provided user: {option.value}"
                         )
 
-                    keyword_args[option.name] = member or option_data.users[id_]
+                    keyword_args[option.name] = member or option.resolve_to_mentionable()
 
             else:
                 value = option.value
@@ -1396,10 +1385,7 @@ class SlashCommand(BaseSlashCommand, abc.SlashCommand, typing.Generic[CommandCal
             await own_hooks.trigger_pre_execution(ctx, hooks=hooks)
 
             if self._tracked_options:
-                options = option.options if option else None
-                kwargs = await self._process_args(
-                    ctx, options or ctx.interaction.options or _EMPTY_LIST, ctx.interaction.resolved or _EMPTY_RESOLVED
-                )
+                kwargs = await self._process_args(ctx)
 
             else:
                 kwargs = _EMPTY_DICT
@@ -1527,7 +1513,7 @@ class MessageCommand(PartialCommand[abc.MessageContext], abc.MessageCommand, typ
 
     @property
     # <<inherited docstring from tanjun.abc.MessageCommand>>.
-    def names(self) -> collections.Set[str]:
+    def names(self) -> collections.Collection[str]:
         return self._names.copy()
 
     @property
@@ -1679,7 +1665,7 @@ class MessageCommandGroup(MessageCommand[CommandCallbackSigT], abc.MessageComman
         return f"CommandGroup <{len(self._commands)}: {self._names}>"
 
     @property
-    def commands(self) -> collections.Set[abc.MessageCommand]:
+    def commands(self) -> collections.Collection[abc.MessageCommand]:
         # <<inherited docstring from tanjun.abc.MessageCommandGroup>>.
         return self._commands.copy()
 

--- a/tanjun/commands.py
+++ b/tanjun/commands.py
@@ -1317,7 +1317,6 @@ class SlashCommand(BaseSlashCommand, abc.SlashCommand, typing.Generic[CommandCal
 
         keyword_args: dict[str, typing.Union[int, float, str, hikari.User, hikari.Role, hikari.InteractionChannel]] = {}
         for tracked_option in self._tracked_options.values():
-            # TODO: investigate difference between not present and None
             if not (option := ctx.options.get(tracked_option.name)):
                 if tracked_option.default is _UNDEFINED_DEFAULT:
                     raise RuntimeError(  # TODO: ConversionError?

--- a/tanjun/components.py
+++ b/tanjun/components.py
@@ -170,7 +170,7 @@ class Component(abc.Component):
         return f"{type(self).__name__}({self.checks=}, {self.hooks=}, {self.slash_hooks=}, {self.message_hooks=})"
 
     @property
-    def checks(self) -> collections.Set[abc.CheckSig]:
+    def checks(self) -> collections.Collection[abc.CheckSig]:
         return {check.callback for check in self._checks}
 
     @property
@@ -186,7 +186,7 @@ class Component(abc.Component):
         return self._name
 
     @property
-    def slash_commands(self) -> collections.ValuesView[abc.BaseSlashCommand]:
+    def slash_commands(self) -> collections.Collection[abc.BaseSlashCommand]:
         return self._slash_commands.copy().values()
 
     @property
@@ -194,7 +194,7 @@ class Component(abc.Component):
         return self._slash_hooks
 
     @property
-    def message_commands(self) -> collections.Set[abc.MessageCommand]:
+    def message_commands(self) -> collections.Collection[abc.MessageCommand]:
         return self._message_commands.copy()
 
     @property

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -277,12 +277,12 @@ class TestCastedView:
     def test___iter__(self):
         mock_iter = iter((1, 2, 3))
         mock_dict = mock.Mock(__iter__=mock.Mock(return_value=mock_iter))
-        view = utilities.CastedView(mock_dict, mock.Mock())
+        view = utilities.CastedView[int, int](mock_dict, mock.Mock())
 
         assert iter(view) is mock_dict.__iter__.return_value
 
     def test___len___(self):
         mock_dict = mock.Mock(__len__=mock.Mock(return_value=43123))
-        view = utilities.CastedView(mock_dict, mock.Mock())
+        view = utilities.CastedView[int, int](mock_dict, mock.Mock())
 
         assert len(view) == 43123


### PR DESCRIPTION
+ Annotate implementation functions which return collections as returning collections.abc.Collection instead of an impl specific subclass of collection