### PR TITLE
Remove deprecated tracked command id behaviours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Renamed `Client.clear_commands` to `Client.clear_slash_commands`.
 
+### Fixed
+- Don't include the "tracked command ID" in slash command group builders as this leads to mis-matching ID
+  errors while declaring.
+
+### Removed
+- BaseSlashCommand.tracked_command_id is no-longer used in command builders and cannot passed to
+  `as_slash_command`, `slash_command_group`, `SlashCommand.__init__` and `SlashCommandGroup.__init__`
+  as `command_id` anymore.
+
 ## [2.1.4a1] - 2021-11-15
 ### Added
 - `injecting.SelfInjectingCallback` and `tanjun.as_self_injecting` to let users make a callback self-injecting 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `clear_slash_commands`, `declare_global_commands`, `declare_slash_command` and 
   `declare_slash_commands` to the Client abstract interface.
 - Client and Component are now bound to a specific event loop with said loop being exposed by a `loop` property.
+- `BaseSlashCommand.tracked_command`.
 
 ### Changed
 - Renamed `Client.clear_commands` to `Client.clear_slash_commands`.

--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -2084,12 +2084,13 @@ class BaseSlashCommand(ExecutableCommand[SlashContext], abc.ABC):
         """Object of the group this command is in."""
 
     @property
+    def tracked_command(self) -> typing.Optional[hikari.Command]:
+        """Object of the actual command this object tracks if set."""
+
+    @property
     @abc.abstractmethod
     def tracked_command_id(self) -> typing.Optional[hikari.Snowflake]:
-        """ID of the actual command this object tracks if set.
-
-        This will be used when this command is used in bulk declarations.
-        """
+        """ID of the actual command this object tracks if set."""
 
     @abc.abstractmethod
     def build(self) -> hikari.api.CommandBuilder:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -260,7 +260,6 @@ def test_as_slash_command_with_defaults():
 
     command = tanjun.as_slash_command("a_very", "cool name")(mock_callback)
 
-    assert command.tracked_command_id is None
     assert command.build().default_permission is hikari.UNDEFINED
     assert command.defaults_to_ephemeral is None
     assert command.is_global is True
@@ -666,11 +665,17 @@ class TestBaseSlashCommand:
 
         assert command.set_parent(mock_parent).parent is mock_parent
 
+    def test_tracked_command_property(self):
+        command = stub_class(tanjun.BaseSlashCommand)("yee", "nsoosos")
+        mock_command = mock.Mock()
+
+        assert command.set_tracked_command(mock_command).tracked_command is mock_command
+
     def test_tracked_command_id_property(self):
         command = stub_class(tanjun.BaseSlashCommand)("yee", "nsoosos")
-        mock_command = mock.Mock(hikari.Command, __int__=mock.Mock(return_value=5312123))
+        mock_command = mock.Mock()
 
-        assert command.set_tracked_command(mock_command).tracked_command_id == 5312123
+        assert command.set_tracked_command(mock_command).tracked_command_id is mock_command.id
 
     @pytest.mark.skip(reason="TODO")
     @pytest.mark.asyncio()
@@ -754,17 +759,6 @@ class TestSlashCommandGroup:
                     options=mock_command_group.build.return_value.options,  # type: ignore
                 )
             )
-        )
-
-    def test_build_when_tracked_command_set(self):
-        command_group = tanjun.SlashCommandGroup("yee", "nsoosos").set_tracked_command(
-            mock.Mock(hikari.Command, __int__=mock.Mock(return_value=123))
-        )
-
-        result = command_group.build()
-
-        assert result == (
-            tanjun.commands._CommandBuilder("yee", "nsoosos", False).set_id(123).set_default_permission(True)
         )
 
     @pytest.mark.skip(reason="TODO")


### PR DESCRIPTION
This includes not being able to set it in slash command initialiser and make functions anymore and it not being used for command builders anymore

### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
