### PR TITLE
Rename slash declare and clear client methods to be app oriented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Upgraded `is_alive` attribute to the Client abstract interface.
-- Upgraded `clear_slash_commands`, `declare_global_commands`, `declare_slash_command` and 
+- Upgraded `clear_application_commands`, `declare_global_commands`, `declare_slash_command` and 
   `declare_slash_commands` to the Client abstract interface.
 - `Client.dispatch_client_callback` and `ClientCallbackNames` to the abstract interface.
 - Client and Component are now bound to a specific event loop with said loop being exposed by a `loop` property.
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Command cooldowns.
 
 ### Changed
-- Renamed `Client.clear_commands` to `Client.clear_slash_commands`.
+- Renamed `Client.clear_commands` to `Client.clear_application_commands`.
+- Renamed `declare_slash_command` and `declare_slash_commands` to `declare_application_command` and
+  `declare_application_commands` respectively.
 
 ### Fixed
 - Don't include the "tracked command ID" in slash command group builders as this leads to mis-matching ID

--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -2917,7 +2917,7 @@ class Client(abc.ABC):
         """Object of the Hikari voice component this client was initialised with."""
 
     @abc.abstractmethod
-    async def clear_slash_commands(
+    async def clear_application_commands(
         self,
         *,
         application: typing.Optional[hikari.SnowflakeishOr[hikari.PartialApplication]] = None,
@@ -2995,7 +2995,7 @@ class Client(abc.ABC):
         """
 
     @abc.abstractmethod
-    async def declare_slash_command(
+    async def declare_application_command(
         self,
         command: BaseSlashCommand,
         /,
@@ -3037,7 +3037,7 @@ class Client(abc.ABC):
         """
 
     @abc.abstractmethod
-    async def declare_slash_commands(
+    async def declare_application_commands(
         self,
         commands: collections.Iterable[BaseSlashCommand],
         /,

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -900,7 +900,7 @@ class Client(injecting.InjectorClient, tanjun_abc.Client):
     async def _on_stopping_event(self, _: hikari.StoppingEvent, /) -> None:
         await self.close()
 
-    async def clear_slash_commands(
+    async def clear_application_commands(
         self,
         *,
         application: typing.Optional[hikari.SnowflakeishOr[hikari.PartialApplication]] = None,
@@ -948,11 +948,11 @@ class Client(injecting.InjectorClient, tanjun_abc.Client):
             )
             if command.is_global
         )
-        return await self.declare_slash_commands(
+        return await self.declare_application_commands(
             commands, command_ids, application=application, guild=guild, force=force
         )
 
-    async def declare_slash_command(
+    async def declare_application_command(
         self,
         command: tanjun_abc.BaseSlashCommand,
         /,
@@ -987,7 +987,7 @@ class Client(injecting.InjectorClient, tanjun_abc.Client):
 
         return response
 
-    async def declare_slash_commands(
+    async def declare_application_commands(
         self,
         commands: collections.Iterable[tanjun_abc.BaseSlashCommand],
         /,

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -328,12 +328,12 @@ class TestClient:
         assert client.voice is None
 
     @pytest.mark.asyncio()
-    async def test_declare_slash_command_when_command_id_provided(self):
+    async def test_declare_application_command_when_command_id_provided(self):
         rest = mock.AsyncMock()
         client = tanjun.Client(rest)
         mock_command = mock.Mock()
 
-        result = await client.declare_slash_command(mock_command, 123321, application=54123, guild=65234)
+        result = await client.declare_application_command(mock_command, 123321, application=54123, guild=65234)
 
         assert result is rest.edit_application_command.return_value
         rest.edit_application_command.assert_called_once_with(
@@ -349,13 +349,13 @@ class TestClient:
         mock_command.set_tracked_command.assert_not_called()
 
     @pytest.mark.asyncio()
-    async def test_declare_slash_command_when_command_id_provided_and_cached_app_id(self):
+    async def test_declare_application_command_when_command_id_provided_and_cached_app_id(self):
         rest = mock.AsyncMock()
         client = tanjun.Client(rest)
         client._cached_application_id = hikari.Snowflake(54123123)
         mock_command = mock.Mock()
 
-        result = await client.declare_slash_command(mock_command, 123321, guild=65234)
+        result = await client.declare_application_command(mock_command, 123321, guild=65234)
 
         assert result is rest.edit_application_command.return_value
         rest.edit_application_command.assert_called_once_with(
@@ -371,7 +371,7 @@ class TestClient:
         mock_command.set_tracked_command.assert_not_called()
 
     @pytest.mark.asyncio()
-    async def test_declare_slash_command_when_command_id_provided_fetchs_app_id(self):
+    async def test_declare_application_command_when_command_id_provided_fetchs_app_id(self):
         fetch_rest_application_id_ = mock.AsyncMock()
 
         class StubClient(tanjun.Client):
@@ -381,7 +381,7 @@ class TestClient:
         client = StubClient(rest)
         mock_command = mock.Mock()
 
-        result = await client.declare_slash_command(mock_command, 123321, guild=65234)
+        result = await client.declare_application_command(mock_command, 123321, guild=65234)
 
         assert result is rest.edit_application_command.return_value
         rest.edit_application_command.assert_called_once_with(
@@ -398,12 +398,12 @@ class TestClient:
         mock_command.set_tracked_command.assert_not_called()
 
     @pytest.mark.asyncio()
-    async def test_declare_slash_command(self):
+    async def test_declare_application_command(self):
         rest = mock.AsyncMock()
         client = tanjun.Client(rest)
         mock_command = mock.Mock()
 
-        result = await client.declare_slash_command(mock_command, application=54123, guild=65234)
+        result = await client.declare_application_command(mock_command, application=54123, guild=65234)
 
         assert result is rest.create_application_command.return_value
         rest.create_application_command.assert_called_once_with(
@@ -418,13 +418,13 @@ class TestClient:
         mock_command.set_tracked_command.assert_not_called()
 
     @pytest.mark.asyncio()
-    async def test_declare_slash_command_when_cached_app_id(self):
+    async def test_declare_application_command_when_cached_app_id(self):
         rest = mock.AsyncMock()
         client = tanjun.Client(rest)
         client._cached_application_id = hikari.Snowflake(54123123)
         mock_command = mock.Mock()
 
-        result = await client.declare_slash_command(mock_command, guild=65234)
+        result = await client.declare_application_command(mock_command, guild=65234)
 
         assert result is rest.create_application_command.return_value
         rest.create_application_command.assert_called_once_with(
@@ -439,7 +439,7 @@ class TestClient:
         mock_command.set_tracked_command.assert_not_called()
 
     @pytest.mark.asyncio()
-    async def test_declare_slash_command_fetchs_app_id(self):
+    async def test_declare_application_command_fetchs_app_id(self):
         fetch_rest_application_id_ = mock.AsyncMock()
 
         class StubClient(tanjun.Client):
@@ -449,7 +449,7 @@ class TestClient:
         client = StubClient(rest)
         mock_command = mock.Mock()
 
-        result = await client.declare_slash_command(mock_command, guild=65234)
+        result = await client.declare_application_command(mock_command, guild=65234)
 
         assert result is rest.create_application_command.return_value
         rest.create_application_command.assert_called_once_with(
@@ -466,7 +466,7 @@ class TestClient:
 
     @pytest.mark.skip(reason="TODO")
     @pytest.mark.asyncio()
-    async def test_declare_slash_commands(self):
+    async def test_declare_application_commands(self):
         ...
 
     @pytest.mark.skip(reason="TODO")


### PR DESCRIPTION
### Summary
Rename slash declare and clear client methods to be app oriented

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [x] I have run `nox` and all the pipelines have passed.
- [x] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
