### PR TITLE
Ignore `delete_after` for ephemeral responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bumped the minimum hikari version to hikari~=2.0.0.dev105.
+- `delete_after` is now ignored for ephemeral responses instead of leading to a 404.
 
 ### Fixed
 - The client level ephemeral default is now respected for REST-based slash command execution.

--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -452,7 +452,11 @@ class Context(abc.ABC):
         Other Parameters
         ----------------
         delete_after : typing.Union[datetime.timedelta, float, int, None]
-            If provided, the seconds after which the response message should be delete.
+            If provided, the seconds after which the response message should be deleted.
+
+            .. note::
+                Slash command responses can only be deleted within 14 minutes of the
+                command being received.
 
             .. note::
                 Since (as of writing) ephemeral responses cannot be deleted by the bot,
@@ -530,6 +534,8 @@ class Context(abc.ABC):
         ValueError
             If more than 100 unique objects/entities are passed for
             `role_mentions` or `user_mentions`.
+            If `delete_after` would be more than 14 minutes after the slash
+            command was called.
         TypeError
             If both `attachment` and `attachments` are specified.
         hikari.BadRequestError
@@ -604,7 +610,11 @@ class Context(abc.ABC):
         Other Parameters
         ----------------
         delete_after : typing.Union[datetime.timedelta, float, int, None]
-            If provided, the seconds after which the response message should be delete.
+            If provided, the seconds after which the response message should be deleted.
+
+            .. note::
+                Slash command responses can only be deleted within 14 minutes of the
+                command being received.
 
             .. note::
                 Since (as of writing) ephemeral responses cannot be deleted by the bot,
@@ -684,6 +694,8 @@ class Context(abc.ABC):
         ValueError
             If more than 100 unique objects/entities are passed for
             `role_mentions` or `user_mentions`.
+            If `delete_after` would be more than 14 minutes after the slash
+            command was called.
         TypeError
             If both `attachment` and `attachments` are specified.
         hikari.BadRequestError
@@ -820,13 +832,19 @@ class Context(abc.ABC):
         Other Parameters
         ----------------
         ensure_result : bool
-            If provided and set to `True` then this will always return `hikari.Message`,
-            otherwise this will return `Optional[hikari.Message]`.
+            Ensure that this call will always return a message object.
+
+            If `True` then this will always return `hikari.Message`, otherwise
+            this will return `Optional[hikari.Message]`.
 
             It's worth noting that, under certain scenarios within the slash
             command flow, this may lead to an extre request being made.
         delete_after : typing.Union[datetime.timedelta, float, int, None]
-            If provided, the seconds after which the response message should be delete.
+            If provided, the seconds after which the response message should be deleted.
+
+            .. note::
+                Slash command responses can only be deleted within 14 minutes of the
+                command being received.
 
             .. note::
                 Since (as of writing) ephemeral responses cannot be deleted by the bot,
@@ -870,6 +888,8 @@ class Context(abc.ABC):
         ValueError
             If more than 100 unique objects/entities are passed for
             `role_mentions` or `user_mentions`.
+            If `delete_after` would be more than 14 minutes after the slash
+            command was called.
         TypeError
             If both `attachment` and `attachments` are specified.
         hikari.BadRequestError
@@ -1004,15 +1024,12 @@ class MessageContext(Context, abc.ABC):
         Other Parameters
         ----------------
         ensure_result : bool
-            This parameter does nothing in the message command flow, as the result
-            will always be available, but is present to keep the signature
-            compatible with `Context.respond`.
-        delete_after : typing.Union[datetime.timedelta, float, int, None]
-            If provided, the seconds after which the response message should be delete.
+            Ensure this method call will return a message object.
 
-            .. note::
-                Since (as of writing) ephemeral responses cannot be deleted by the bot,
-                this is ignored for ephemeral slash command responses.
+            This does nothing for message command contexts as the result w ill
+            always be immedieatly available.
+        delete_after : typing.Union[datetime.timedelta, float, int, None]
+            If provided, the seconds after which the response message should be deleted.
         tts : hikari.UndefinedOr[bool]
             Whether to respond with tts/text to speech or no.
         reply : typing.Union[bool, hikari.SnowflakeishOr[hikari.PartialMessage], hikari.UndefinedType]
@@ -1443,7 +1460,11 @@ class SlashContext(Context, abc.ABC):
         Other Parameters
         ----------------
         delete_after : typing.Union[datetime.timedelta, float, int, None]
-            If provided, the seconds after which the response message should be delete.
+            If provided, the seconds after which the response message should be deleted.
+
+            .. note::
+                Slash command responses can only be deleted within 14 minutes of the
+                command being received.
 
             .. note::
                 Since (as of writing) ephemeral responses cannot be deleted by the bot,
@@ -1546,7 +1567,11 @@ class SlashContext(Context, abc.ABC):
         Other Parameters
         ----------------
         delete_after : typing.Union[datetime.timedelta, float, int, None]
-            If provided, the seconds after which the response message should be delete.
+            If provided, the seconds after which the response message should be deleted.
+
+            .. note::
+                Slash command responses can only be deleted within 14 minutes of the
+                command being received.
 
             .. note::
                 Since (as of writing) ephemeral responses cannot be deleted by the bot,

--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -455,7 +455,8 @@ class Context(abc.ABC):
             If provided, the seconds after which the response message should be delete.
 
             .. note::
-                As of writing, this does not support ephemeral slash command responses.
+                Since (as of writing) ephemeral responses cannot be deleted by the bot,
+                this is ignored for ephemeral slash command responses.
         attachment : hikari.UndefinedOr[hikari.Resourceish]
             A singular attachment to edit the initial response with.
         attachments : hikari.UndefinedOr[collections.abc.Sequence[hikari.Resourceish]]
@@ -606,7 +607,8 @@ class Context(abc.ABC):
             If provided, the seconds after which the response message should be delete.
 
             .. note::
-                As of writing, this does not support ephemeral slash command responses.
+                Since (as of writing) ephemeral responses cannot be deleted by the bot,
+                this is ignored for ephemeral slash command responses.
         attachment : hikari.UndefinedOr[hikari.Resourceish]
             A singular attachment to edit the last response with.
         attachments : hikari.UndefinedOr[collections.abc.Sequence[hikari.Resourceish]]
@@ -827,7 +829,8 @@ class Context(abc.ABC):
             If provided, the seconds after which the response message should be delete.
 
             .. note::
-                As of writing, this does not support ephemeral slash command responses.
+                Since (as of writing) ephemeral responses cannot be deleted by the bot,
+                this is ignored for ephemeral slash command responses.
         component : hikari.UndefinedOr[hikari.api.ComponentBuilder]
             If provided, builder object of the component to include in this response.
         components : hikari.UndefinedOr[collections.abc.Sequence[hikari.api.ComponentBuilder]]
@@ -1008,7 +1011,8 @@ class MessageContext(Context, abc.ABC):
             If provided, the seconds after which the response message should be delete.
 
             .. note::
-                As of writing, this does not support ephemeral slash command responses.
+                Since (as of writing) ephemeral responses cannot be deleted by the bot,
+                this is ignored for ephemeral slash command responses.
         tts : hikari.UndefinedOr[bool]
             Whether to respond with tts/text to speech or no.
         reply : typing.Union[bool, hikari.SnowflakeishOr[hikari.PartialMessage], hikari.UndefinedType]
@@ -1442,7 +1446,8 @@ class SlashContext(Context, abc.ABC):
             If provided, the seconds after which the response message should be delete.
 
             .. note::
-                As of writing, this does not support ephemeral slash command responses.
+                Since (as of writing) ephemeral responses cannot be deleted by the bot,
+                this is ignored for ephemeral slash command responses.
         attachment : hikari.UndefinedOr[hikari.Resourceish]
             If provided, the message attachment. This can be a resource,
             or string of a path on your computer or a URL.
@@ -1544,7 +1549,8 @@ class SlashContext(Context, abc.ABC):
             If provided, the seconds after which the response message should be delete.
 
             .. note::
-                As of writing, this does not support ephemeral slash command responses.
+                Since (as of writing) ephemeral responses cannot be deleted by the bot,
+                this is ignored for ephemeral slash command responses.
         content : hikari.UndefinedOr[typing.Any]
             If provided, the message contents. If
             `hikari.UNDEFINED`, then nothing will be sent

--- a/tanjun/context.py
+++ b/tanjun/context.py
@@ -1205,7 +1205,7 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
         )
         self._has_responded = True
 
-        if delete_after is not None and not (message.flags & hikari.MessageFlag.EPHEMERAL):
+        if delete_after is not None and not message.flags & hikari.MessageFlag.EPHEMERAL:
             asyncio.create_task(self._delete_initial_response_after(delete_after))
 
         return message

--- a/tanjun/context.py
+++ b/tanjun/context.py
@@ -815,11 +815,11 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
 
     def _get_flags(
         self, flags: typing.Union[hikari.UndefinedType, int, hikari.MessageFlag] = hikari.UNDEFINED
-    ) -> typing.Union[hikari.UndefinedType, int, hikari.MessageFlag]:
+    ) -> typing.Union[int, hikari.MessageFlag]:
         if flags is hikari.UNDEFINED:
             return hikari.MessageFlag.EPHEMERAL if self._defaults_to_ephemeral else hikari.MessageFlag.NONE
 
-        return flags
+        return flags or hikari.MessageFlag.NONE
 
     def get_response_future(self) -> asyncio.Future[ResponseTypeT]:
         """Get the future which will be used to set the initial response.
@@ -970,8 +970,14 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
             role_mentions=role_mentions,
         )
         self._last_response_id = message.id
+        # This behaviour is undocumented and only kept by Discord for "backwards compatibility"
+        # but the followup endpoint can be used to create the initial response for slash
+        # commands or edit in a deferred response and (while this does lead to some
+        # unexpected behaviour around deferrals) should be accounted for.
+        if not self._has_responded:
+            self._has_responded = True
 
-        if delete_after is not None:
+        if delete_after is not None and not message.flags & hikari.MessageFlag.EPHEMERAL:
             asyncio.create_task(self._delete_followup_after(delete_after, message))
 
         return message
@@ -1103,7 +1109,7 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
 
             self._response_future.set_result(result)
 
-        if delete_after is not None:
+        if delete_after is not None and not flags & hikari.MessageFlag.EPHEMERAL:
             asyncio.create_task(self._delete_initial_response_after(delete_after))
 
     async def create_initial_response(
@@ -1184,7 +1190,7 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
     ) -> hikari.Message:
         # <<inherited docstring from tanjun.abc.Context>>.
         delete_after = self._validate_delete_after(delete_after) if delete_after is not None else None
-        result = await self._interaction.edit_initial_response(
+        message = await self._interaction.edit_initial_response(
             content=content,
             attachment=attachment,
             attachments=attachments,
@@ -1199,10 +1205,10 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
         )
         self._has_responded = True
 
-        if delete_after is not None:
+        if delete_after is not None and not (message.flags & hikari.MessageFlag.EPHEMERAL):
             asyncio.create_task(self._delete_initial_response_after(delete_after))
 
-        return result
+        return message
 
     async def edit_last_response(
         self,
@@ -1241,7 +1247,7 @@ class SlashContext(BaseContext, tanjun_abc.SlashContext):
                 user_mentions=user_mentions,
                 role_mentions=role_mentions,
             )
-            if delete_after is not None:
+            if delete_after is not None and not message.flags & hikari.MessageFlag.EPHEMERAL:
                 asyncio.create_task(self._delete_followup_after(delete_after, message))
 
             return message


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
