### PR TITLE
Relax menu command name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Relaxed menu command name validation to allow special characters and mixed cases.
 
 ## [2.4.0a1] - 2022-02-11
 ### Added

--- a/tanjun/commands/menu.py
+++ b/tanjun/commands/menu.py
@@ -43,7 +43,6 @@ from .. import hooks as hooks_
 from .. import injecting
 from .. import utilities
 from . import base
-from . import slash
 
 if typing.TYPE_CHECKING:
     from collections import abc as collections
@@ -289,7 +288,8 @@ class MenuCommand(base.PartialCommand[abc.MenuContext], abc.MenuCommand[_MenuCom
         _wrapped_command: typing.Optional[abc.ExecutableCommand[typing.Any]] = None,
     ) -> None:
         super().__init__()
-        slash.validate_name(name)
+        if not name or len(name) > 32:
+            raise ValueError(f"Command name must be between 1-32 characters in length")
 
         if type_ not in _VALID_TYPES:
             raise ValueError("Command type must be message or user")

--- a/tanjun/commands/menu.py
+++ b/tanjun/commands/menu.py
@@ -289,7 +289,7 @@ class MenuCommand(base.PartialCommand[abc.MenuContext], abc.MenuCommand[_MenuCom
     ) -> None:
         super().__init__()
         if not name or len(name) > 32:
-            raise ValueError(f"Command name must be between 1-32 characters in length")
+            raise ValueError("Command name must be between 1-32 characters in length")
 
         if type_ not in _VALID_TYPES:
             raise ValueError("Command type must be message or user")

--- a/tanjun/commands/slash.py
+++ b/tanjun/commands/slash.py
@@ -90,7 +90,7 @@ _AutocompleteCallbackSigT = typing.TypeVar("_AutocompleteCallbackSigT", bound=ab
 _SCOMMAND_NAME_REG: typing.Final[re.Pattern[str]] = re.compile(r"^[\w-]{1,32}$", flags=re.UNICODE)
 
 
-def validate_name(name: str) -> None:
+def _validate_name(name: str) -> None:
     if not _SCOMMAND_NAME_REG.fullmatch(name):
         raise ValueError(f"Invalid name provided, {name!r} doesn't match the required regex `^\\w{{1,32}}$`")
 
@@ -751,7 +751,7 @@ class BaseSlashCommand(base.PartialCommand[abc.SlashContext], abc.BaseSlashComma
         is_global: bool = True,
     ) -> None:
         super().__init__()
-        validate_name(name)
+        _validate_name(name)
         if len(description) > 100:
             raise ValueError("The command description cannot be over 100 characters in length")
 
@@ -1263,7 +1263,7 @@ class SlashCommand(BaseSlashCommand, abc.SlashCommand[abc.CommandCallbackSigT]):
         pass_as_kwarg: bool = True,
         _stack_level: int = 0,
     ) -> _SlashCommandT:
-        validate_name(name)
+        _validate_name(name)
         if len(description) > 100:
             raise ValueError("The option description cannot be over 100 characters in length")
 

--- a/tests/commands/test_menu.py
+++ b/tests/commands/test_menu.py
@@ -35,7 +35,6 @@
 # pyright: reportPrivateUsage=none
 # This leads to too many false-positives around mocks.
 
-import re
 import typing
 from unittest import mock
 
@@ -157,21 +156,20 @@ def test_as_user_menu_when_wrapping_command(
     assert isinstance(command, tanjun.MenuCommand)
 
 
-_INVALID_NAMES = ["a" * 33, "", "'#'#42123"]
-
-
 class TestMenuCommand:
-    @pytest.mark.parametrize("name", _INVALID_NAMES)
-    def test__init__with_invalid_name(self, name: str):
+    def test__init__when_name_too_long(self):
         with pytest.raises(
             ValueError,
-            match=f"Invalid name provided, {name!r} doesn't match the required regex " + re.escape(r"`^\w{1,32}$`"),
+            match="Command name must be between 1-32 characters in length",
         ):
-            tanjun.commands.MenuCommand(mock.Mock(), hikari.CommandType.MESSAGE, name)
+            tanjun.commands.MenuCommand(mock.Mock(), hikari.CommandType.MESSAGE, "x" * 33)
 
-    def test__init__when_name_isnt_lowercase(self):
-        with pytest.raises(ValueError, match="Invalid name provided, 'EAttststs' must be lowercase"):
-            tanjun.commands.MenuCommand(mock.Mock(), hikari.CommandType.MESSAGE, "EAttststs")
+    def test__init__when_no_name(self):
+        with pytest.raises(
+            ValueError,
+            match="Command name must be between 1-32 characters in length",
+        ):
+            tanjun.commands.MenuCommand(mock.Mock(), hikari.CommandType.MESSAGE, "")
 
     @pytest.mark.parametrize(
         "inner_command",


### PR DESCRIPTION
### Summary
Relax menu command name validation

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes: #209
