### PR TITLE
Switch over to using discord's time repr for cooldowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The cooldown limiter now uses Discord's timestamp format in its default error messages.
+- `AbstractCooldownManager.check_cooldown` now returns a `datetime.timedelta` instead of a  `float`.
 
 ## [2.5.1a1] - 2022-05-02
 ### Added

--- a/tanjun/dependencies/limiters.py
+++ b/tanjun/dependencies/limiters.py
@@ -50,7 +50,6 @@ import asyncio
 import datetime
 import enum
 import logging
-import time
 import typing
 from collections import abc as collections
 
@@ -80,7 +79,7 @@ class AbstractCooldownManager(abc.ABC):
     @abc.abstractmethod
     async def check_cooldown(
         self, bucket_id: str, ctx: tanjun.Context, /, *, increment: bool = False
-    ) -> typing.Optional[datetime.timedelta]:
+    ) -> typing.Optional[datetime.datetime]:
         """Check if a bucket is on cooldown for the provided context.
 
         Parameters
@@ -263,18 +262,22 @@ async def _get_ctx_target(ctx: tanjun.Context, type_: BucketResource, /) -> hika
 _CooldownT = typing.TypeVar("_CooldownT", bound="_Cooldown")
 
 
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(tz=datetime.timezone.utc)
+
+
 class _Cooldown:
     __slots__ = ("counter", "limit", "reset_after", "resets_at")
 
-    def __init__(self, *, limit: int, reset_after: float) -> None:
+    def __init__(self, *, limit: int, reset_after: datetime.timedelta) -> None:
         self.counter = 0
         self.limit = limit
         self.reset_after = reset_after
-        self.resets_at = time.monotonic() + reset_after
+        self.resets_at = _now() + reset_after
 
     def has_expired(self) -> bool:
         # Expiration doesn't actually matter for cases where the limit is -1.
-        return time.monotonic() >= self.resets_at
+        return _now() >= self.resets_at
 
     def increment(self: _CooldownT) -> _CooldownT:
         # A limit of -1 is special cased to mean no limit, so there's no need to increment the counter.
@@ -282,9 +285,9 @@ class _Cooldown:
             return self
 
         if self.counter == 0:
-            self.resets_at = time.monotonic() + self.reset_after
+            self.resets_at = _now() + self.reset_after
 
-        elif (current_time := time.monotonic()) >= self.resets_at:
+        elif (current_time := _now()) >= self.resets_at:
             self.counter = 0
             self.resets_at = current_time + self.reset_after
 
@@ -293,13 +296,13 @@ class _Cooldown:
 
         return self
 
-    def must_wait_for(self) -> typing.Optional[datetime.timedelta]:
+    def must_wait_until(self) -> typing.Optional[datetime.datetime]:
         # A limit of -1 is special cased to mean no limit, so we don't need to wait.
         if self.limit == -1:
             return None
 
-        if self.counter >= self.limit and (time_left := self.resets_at - time.monotonic()) > 0:
-            return datetime.timedelta(seconds=time_left)
+        if self.counter >= self.limit and self.resets_at > _now():
+            return self.resets_at
 
 
 class _InnerResourceProto(typing.Protocol):
@@ -475,7 +478,7 @@ class InMemoryCooldownManager(AbstractCooldownManager):
     def __init__(self) -> None:
         self._buckets: dict[str, _BaseResource[_Cooldown]] = {}
         self._default_bucket_template: _BaseResource[_Cooldown] = _FlatResource(
-            BucketResource.USER, lambda: _Cooldown(limit=2, reset_after=5)
+            BucketResource.USER, lambda: _Cooldown(limit=2, reset_after=datetime.timedelta(seconds=5))
         )
         self._gc_task: typing.Optional[asyncio.Task[None]] = None
 
@@ -514,19 +517,19 @@ class InMemoryCooldownManager(AbstractCooldownManager):
 
     async def check_cooldown(
         self, bucket_id: str, ctx: tanjun.Context, /, *, increment: bool = False
-    ) -> typing.Optional[datetime.timedelta]:
+    ) -> typing.Optional[datetime.datetime]:
         # <<inherited docstring from AbstractCooldownManager>>.
         bucket: typing.Optional[_Cooldown]
         if increment:
             bucket = await self._get_or_default(bucket_id).into_inner(ctx)
-            if cooldown := bucket.must_wait_for():
+            if cooldown := bucket.must_wait_until():
                 return cooldown
 
             bucket.increment()
             return None
 
         if (resource := self._buckets.get(bucket_id)) and (bucket := await resource.try_into_inner(ctx)):
-            return bucket.must_wait_for()
+            return bucket.must_wait_until()
 
     async def increment_cooldown(self, bucket_id: str, ctx: tanjun.Context, /) -> None:
         # <<inherited docstring from AbstractCooldownManager>>.
@@ -581,7 +584,9 @@ class InMemoryCooldownManager(AbstractCooldownManager):
             This cooldown manager to allow for chaining.
         """
         # A limit of -1 is special cased to mean no limit and reset_after is ignored in this scenario.
-        bucket = self._buckets[bucket_id] = _GlobalResource(lambda: _Cooldown(limit=-1, reset_after=-1))
+        bucket = self._buckets[bucket_id] = _GlobalResource(
+            lambda: _Cooldown(limit=-1, reset_after=datetime.timedelta(-1))
+        )
         if bucket_id == "default":
             self._default_bucket_template = bucket.copy()
 
@@ -624,19 +629,17 @@ class InMemoryCooldownManager(AbstractCooldownManager):
             If reset_after or limit are negative, 0 or invalid.
             if limit is less 0 or negative.
         """
-        if isinstance(reset_after, datetime.timedelta):
-            reset_after_seconds = reset_after.total_seconds()
-        else:
-            reset_after_seconds = float(reset_after)
+        if not isinstance(reset_after, datetime.timedelta):
+            reset_after = datetime.timedelta(seconds=reset_after)
 
-        if reset_after_seconds <= 0:
+        if reset_after.total_seconds() <= 0:
             raise ValueError("reset_after must be greater than 0 seconds")
 
         if limit <= 0:
             raise ValueError("limit must be greater than 0")
 
         bucket = self._buckets[bucket_id] = _to_bucket(
-            BucketResource(resource), lambda: _Cooldown(limit=limit, reset_after=reset_after_seconds)
+            BucketResource(resource), lambda: _Cooldown(limit=limit, reset_after=reset_after)
         )
         if bucket_id == "default":
             self._default_bucket_template = bucket.copy()
@@ -693,9 +696,7 @@ class CooldownPreExecution:
                 return
 
         if wait_for := await cooldowns.check_cooldown(self._bucket_id, ctx, increment=True):
-            wait_for_repr = conversion.from_datetime(
-                datetime.datetime.now(tz=datetime.timezone.utc) + wait_for, style="R"
-            )
+            wait_for_repr = conversion.from_datetime(wait_for, style="R")
             raise errors.CommandError(self._error_message.format(cooldown=wait_for_repr))
 
 

--- a/tanjun/dependencies/limiters.py
+++ b/tanjun/dependencies/limiters.py
@@ -658,7 +658,7 @@ class CooldownPreExecution:
         bucket_id: str,
         /,
         *,
-        error_message: str = "Command is currently in cooldown. Try again {cooldown}.",
+        error_message: str = "This command is currently in cooldown. Try again {cooldown}.",
         owners_exempt: bool = True,
     ) -> None:
         """Initialise a pre-execution cooldown command hook.
@@ -703,7 +703,7 @@ def with_cooldown(
     bucket_id: str,
     /,
     *,
-    error_message: str = "Command is currently in cooldown. Try again {cooldown}.",
+    error_message: str = "This command is currently in cooldown. Try again {cooldown}.",
     owners_exempt: bool = True,
 ) -> collections.Callable[[_CommandT], _CommandT]:
     """Add a pre-execution hook used to manage a command's cooldown through a decorator call.

--- a/tests/dependencies/test_limiters.py
+++ b/tests/dependencies/test_limiters.py
@@ -35,7 +35,6 @@
 # This leads to too many false-positives around mocks.
 import asyncio
 import datetime
-import time
 import typing
 from unittest import mock
 
@@ -289,98 +288,100 @@ async def test__get_ctx_target_when_unexpected_type():
 
 class Test_Cooldown:
     def test_has_expired_property(self):
-        with mock.patch.object(time, "monotonic", side_effect=[69.0, 72.0]):
-            cooldown = tanjun.dependencies.limiters._Cooldown(limit=1, reset_after=60.0)
+        with freezegun.freeze_time(auto_tick_seconds=3):
+            cooldown = tanjun.dependencies.limiters._Cooldown(limit=1, reset_after=datetime.timedelta(seconds=60))
 
             assert cooldown.has_expired() is False
 
     def test_has_expired_property_when_has_expired(self):
-        with mock.patch.object(time, "monotonic", side_effect=[69.0, 96.0]):
-            cooldown = tanjun.dependencies.limiters._Cooldown(limit=1, reset_after=26.5)
+        with freezegun.freeze_time(auto_tick_seconds=30):
+            cooldown = tanjun.dependencies.limiters._Cooldown(
+                limit=1, reset_after=datetime.timedelta(seconds=26, milliseconds=500)
+            )
 
             assert cooldown.has_expired() is True
 
     def test_increment(self):
-        with mock.patch.object(time, "monotonic", side_effect=[50.0, 55.0]):
-            cooldown = tanjun.dependencies.limiters._Cooldown(limit=5, reset_after=69.420)
+        with freezegun.freeze_time(datetime.datetime(2016, 3, 2, 12, 4, 5), auto_tick_seconds=5):
+            cooldown = tanjun.dependencies.limiters._Cooldown(
+                limit=5, reset_after=datetime.timedelta(seconds=69, milliseconds=420)
+            )
             cooldown.counter = 2
 
             cooldown.increment()
 
             assert cooldown.counter == 3
-            assert cooldown.resets_at == 119.420
+            assert cooldown.resets_at == datetime.datetime(2016, 3, 2, 12, 5, 14, 420000, tzinfo=datetime.timezone.utc)
 
     def test_increment_when_counter_is_0(self):
-        with mock.patch.object(time, "monotonic", side_effect=[419.0, 420.0]):
-            cooldown = tanjun.dependencies.limiters._Cooldown(limit=5, reset_after=69.00)
+        with freezegun.freeze_time(datetime.datetime(2014, 1, 2, 12, 4, 5), auto_tick_seconds=1):
+            cooldown = tanjun.dependencies.limiters._Cooldown(limit=5, reset_after=datetime.timedelta(seconds=69))
 
             cooldown.increment()
 
             assert cooldown.counter == 1
-            assert cooldown.resets_at == 489.00
+            assert cooldown.resets_at == datetime.datetime(2014, 1, 2, 12, 5, 15, tzinfo=datetime.timezone.utc)
 
     def test_increment_when_counter_is_at_limit(self):
-        with mock.patch.object(time, "monotonic", side_effect=[419.0, 420.0]):
-            cooldown = tanjun.dependencies.limiters._Cooldown(limit=5, reset_after=69.00)
+        with freezegun.freeze_time(datetime.datetime(2014, 1, 2, 12, 4, 5), auto_tick_seconds=1):
+            cooldown = tanjun.dependencies.limiters._Cooldown(limit=5, reset_after=datetime.timedelta(seconds=69))
             cooldown.counter = 5
 
             cooldown.increment()
 
             assert cooldown.counter == 5
-            assert cooldown.resets_at == 488.00
+            assert cooldown.resets_at == datetime.datetime(2014, 1, 2, 12, 5, 14, tzinfo=datetime.timezone.utc)
 
     def test_increment_when_passed_reset_after(self):
-        with mock.patch.object(time, "monotonic", side_effect=[419.0, 422.5]):
-            cooldown = tanjun.dependencies.limiters._Cooldown(limit=5, reset_after=2.0)
+        with freezegun.freeze_time(datetime.datetime(2014, 1, 2, 12, 4, 5), auto_tick_seconds=2):
+            cooldown = tanjun.dependencies.limiters._Cooldown(limit=5, reset_after=datetime.timedelta(seconds=2))
             cooldown.counter = 2
 
             cooldown.increment()
 
             assert cooldown.counter == 1
-            assert cooldown.resets_at == 424.5
+            assert cooldown.resets_at == datetime.datetime(2014, 1, 2, 12, 4, 9, tzinfo=datetime.timezone.utc)
 
     def test_increment_when_limit_is_negeative_1(self):
-        cooldown = tanjun.dependencies.limiters._Cooldown(limit=-1, reset_after=-1)
-        cooldown.resets_at = 54345543
+        cooldown = tanjun.dependencies.limiters._Cooldown(limit=-1, reset_after=datetime.timedelta(seconds=-1))
+        cooldown.resets_at = datetime.datetime(2020, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
         cooldown.counter = 123
 
-        with mock.patch.object(time, "monotonic") as monotonic:
-            result = cooldown.increment()
-
-            monotonic.assert_not_called()
+        result = cooldown.increment()
 
         assert result is cooldown
         assert cooldown.counter == 123
-        assert cooldown.resets_at == 54345543
+        assert cooldown.resets_at == datetime.datetime(2020, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
 
-    def test_must_wait_for(self):
-        with mock.patch.object(time, "monotonic", side_effect=[419.0, 422.0]):
-            cooldown = tanjun.dependencies.limiters._Cooldown(reset_after=10.5, limit=3)
+    def test_must_wait_until(self):
+        with freezegun.freeze_time(datetime.datetime(2014, 1, 2, 12, 4, 5), auto_tick_seconds=3):
+            cooldown = tanjun.dependencies.limiters._Cooldown(
+                reset_after=datetime.timedelta(seconds=10, milliseconds=5), limit=3
+            )
             cooldown.counter = 3
 
-            assert cooldown.must_wait_for() == datetime.timedelta(seconds=7, milliseconds=500)
+            assert cooldown.must_wait_until() == datetime.datetime(
+                2014, 1, 2, 12, 4, 15, 5000, tzinfo=datetime.timezone.utc
+            )
 
-    def test_must_wait_for_when_resource_limit_not_hit(self):
-        cooldown = tanjun.dependencies.limiters._Cooldown(reset_after=2.0, limit=3)
+    def test_must_wait_until_when_resource_limit_not_hit(self):
+        cooldown = tanjun.dependencies.limiters._Cooldown(reset_after=datetime.timedelta(seconds=2), limit=3)
         cooldown.counter = 2
 
-        assert cooldown.must_wait_for() is None
+        assert cooldown.must_wait_until() is None
 
-    def test_must_wait_for_when_reset_after_reached(self):
-        with mock.patch.object(time, "monotonic", side_effect=[419.0, 425.5]):
-            cooldown = tanjun.dependencies.limiters._Cooldown(reset_after=5.0, limit=3)
+    def test_must_wait_until_when_reset_after_reached(self):
+        with freezegun.freeze_time(datetime.datetime(2014, 1, 5, 12, 4, 5), auto_tick_seconds=5):
+            cooldown = tanjun.dependencies.limiters._Cooldown(reset_after=datetime.timedelta(seconds=5), limit=3)
             cooldown.counter = 3
 
-            assert cooldown.must_wait_for() is None
+            assert cooldown.must_wait_until() is None
 
-    def test_must_wait_for_when_limit_is_negative_1(self):
-        cooldown = tanjun.dependencies.limiters._Cooldown(reset_after=64, limit=-1)
+    def test_must_wait_until_when_limit_is_negative_1(self):
+        cooldown = tanjun.dependencies.limiters._Cooldown(reset_after=datetime.timedelta(seconds=64), limit=-1)
         cooldown.counter = 55
 
-        with mock.patch.object(time, "monotonic") as monotonic:
-            assert cooldown.must_wait_for() is None
-
-            monotonic.assert_not_called()
+        assert cooldown.must_wait_until() is None
 
 
 class Test_FlatResource:
@@ -780,9 +781,9 @@ class TestInMemoryCooldownManager:
 
         result = await manager.check_cooldown("ok", mock_context, increment=False)
 
-        assert result is mock_bucket.try_into_inner.return_value.must_wait_for.return_value
+        assert result is mock_bucket.try_into_inner.return_value.must_wait_until.return_value
         mock_bucket.try_into_inner.assert_awaited_once_with(mock_context)
-        mock_inner.must_wait_for.assert_called_once_with()
+        mock_inner.must_wait_until.assert_called_once_with()
 
     @pytest.mark.asyncio()
     async def test_check_cooldown_when_try_into_inner_returns_none(self):
@@ -803,7 +804,7 @@ class TestInMemoryCooldownManager:
         mock_bucket = mock.Mock(into_inner=mock.AsyncMock(return_value=mock.Mock()))
         mock_inner: typing.Any = mock_bucket.into_inner.return_value
         mock_inner.increment.return_value = mock_bucket.into_inner.return_value
-        mock_inner.must_wait_for.return_value = None
+        mock_inner.must_wait_until.return_value = None
         manager._buckets["ok"] = mock_bucket
 
         result = await manager.check_cooldown("ok", mock_context, increment=True)
@@ -811,10 +812,10 @@ class TestInMemoryCooldownManager:
         assert result is None
         mock_bucket.into_inner.assert_awaited_once_with(mock_context)
         mock_inner.increment.assert_called_once_with()
-        mock_inner.must_wait_for.assert_called_once_with()
+        mock_inner.must_wait_until.assert_called_once_with()
 
     @pytest.mark.asyncio()
-    async def test_check_cooldown_when_increment_and_must_wait_for_returns_time(self):
+    async def test_check_cooldown_when_increment_and_must_wait_until_returns_time(self):
         manager = tanjun.dependencies.InMemoryCooldownManager()
         mock_context = mock.Mock()
         mock_bucket = mock.Mock(into_inner=mock.AsyncMock(return_value=mock.Mock()))
@@ -824,10 +825,10 @@ class TestInMemoryCooldownManager:
 
         result = await manager.check_cooldown("ok", mock_context, increment=True)
 
-        assert result is mock_inner.must_wait_for.return_value
+        assert result is mock_inner.must_wait_until.return_value
         mock_bucket.into_inner.assert_awaited_once_with(mock_context)
         mock_inner.increment.assert_not_called()
-        mock_inner.must_wait_for.assert_called_once_with()
+        mock_inner.must_wait_until.assert_called_once_with()
 
     @pytest.mark.asyncio()
     async def test_check_cooldown_falls_back_to_default_when_increment_creates_new_bucket(self):
@@ -837,7 +838,7 @@ class TestInMemoryCooldownManager:
         mock_bucket.copy.return_value = mock.Mock(into_inner=mock.AsyncMock(return_value=mock.Mock()))
         mock_inner: typing.Any = mock_bucket.copy.return_value.into_inner.return_value
         mock_inner.increment.return_value = mock_inner
-        mock_inner.must_wait_for.return_value = None
+        mock_inner.must_wait_until.return_value = None
 
         manager._default_bucket_template = mock_bucket
 
@@ -848,7 +849,7 @@ class TestInMemoryCooldownManager:
         mock_bucket.copy.assert_called_once_with()
         mock_bucket.copy.return_value.into_inner.assert_awaited_once_with(mock_context)
         mock_inner.increment.assert_called_once_with()
-        mock_inner.must_wait_for.assert_called_once_with()
+        mock_inner.must_wait_until.assert_called_once_with()
 
     @pytest.mark.asyncio()
     async def test_check_cooldown_falls_back_to_default_when_increment_creates_new_bucket_when_wait_for_returns_time(
@@ -865,12 +866,12 @@ class TestInMemoryCooldownManager:
 
         result = await manager.check_cooldown("ok", mock_context, increment=True)
 
-        assert result is mock_inner.must_wait_for.return_value
+        assert result is mock_inner.must_wait_until.return_value
         assert manager._buckets["ok"] is mock_bucket.copy.return_value
         mock_bucket.copy.assert_called_once_with()
         mock_bucket.copy.return_value.into_inner.assert_awaited_once_with(mock_context)
         mock_inner.increment.assert_not_called()
-        mock_inner.must_wait_for.assert_called_once_with()
+        mock_inner.must_wait_until.assert_called_once_with()
 
     @pytest.mark.asyncio()
     async def test_increment_cooldown(self):
@@ -976,7 +977,7 @@ class TestInMemoryCooldownManager:
             cooldown = cooldown_maker()
             assert isinstance(cooldown, tanjun.dependencies.limiters._Cooldown)
             assert cooldown.limit == -1
-            assert cooldown.reset_after == -1
+            assert cooldown.reset_after == datetime.timedelta(-1)
 
     def test_disable_bucket_when_is_default(self):
         manager = tanjun.dependencies.InMemoryCooldownManager()
@@ -997,7 +998,7 @@ class TestInMemoryCooldownManager:
             cooldown = cooldown_maker()
             assert isinstance(cooldown, tanjun.dependencies.limiters._Cooldown)
             assert cooldown.limit == -1
-            assert cooldown.reset_after == -1
+            assert cooldown.reset_after == datetime.timedelta(-1)
 
     @pytest.mark.parametrize(
         "resource_type",
@@ -1030,7 +1031,7 @@ class TestInMemoryCooldownManager:
             cooldown = cooldown_maker()
             assert isinstance(cooldown, tanjun.dependencies.limiters._Cooldown)
             assert cooldown.limit == 123
-            assert cooldown.reset_after == 43.123
+            assert cooldown.reset_after == datetime.timedelta(seconds=43, milliseconds=123)
 
     @pytest.mark.parametrize("reset_after", [datetime.timedelta(seconds=69), 69, 69.0])
     def test_set_bucket_handles_different_reset_after_types(
@@ -1052,7 +1053,7 @@ class TestInMemoryCooldownManager:
             cooldown = cooldown_maker()
             assert isinstance(cooldown, tanjun.dependencies.limiters._Cooldown)
             assert cooldown.limit == 444
-            assert cooldown.reset_after == 69
+            assert cooldown.reset_after == datetime.timedelta(seconds=69)
 
     def test_set_bucket_for_member_resource(self):
         manager = tanjun.dependencies.InMemoryCooldownManager()
@@ -1070,7 +1071,7 @@ class TestInMemoryCooldownManager:
             cooldown = cooldown_maker()
             assert isinstance(cooldown, tanjun.dependencies.limiters._Cooldown)
             assert cooldown.limit == 64
-            assert cooldown.reset_after == 42.0
+            assert cooldown.reset_after == datetime.timedelta(seconds=42.0)
 
     def test_set_bucket_for_global_resource(self):
         manager = tanjun.dependencies.InMemoryCooldownManager()
@@ -1088,7 +1089,7 @@ class TestInMemoryCooldownManager:
             cooldown = cooldown_maker()
             assert isinstance(cooldown, tanjun.dependencies.limiters._Cooldown)
             assert cooldown.limit == 420
-            assert cooldown.reset_after == 69.420
+            assert cooldown.reset_after == datetime.timedelta(seconds=69, milliseconds=420)
 
     def test_set_bucket_when_is_default(self):
         manager = tanjun.dependencies.InMemoryCooldownManager()
@@ -1110,7 +1111,7 @@ class TestInMemoryCooldownManager:
             cooldown = cooldown_maker()
             assert isinstance(cooldown, tanjun.dependencies.limiters._Cooldown)
             assert cooldown.limit == 777
-            assert cooldown.reset_after == 666.0
+            assert cooldown.reset_after == datetime.timedelta(seconds=666)
 
     @pytest.mark.parametrize("reset_after", [datetime.timedelta(seconds=-42), -431, -0.123])
     def test_set_bucket_when_reset_after_is_negative(self, reset_after: typing.Union[datetime.timedelta, float, int]):
@@ -1184,15 +1185,14 @@ class TestCooldownPreExecution:
         pre_execution = tanjun.dependencies.CooldownPreExecution("yuri", owners_exempt=True)
         mock_context = mock.Mock()
         mock_cooldown_manager = mock.AsyncMock()
-        mock_cooldown_manager.check_cooldown.return_value = datetime.timedelta(seconds=69, milliseconds=420)
+        mock_cooldown_manager.check_cooldown.return_value = datetime.datetime(
+            2012, 1, 14, 12, 1, 9, 420000, tzinfo=datetime.timezone.utc
+        )
         mock_owner_check = mock.AsyncMock()
         mock_owner_check.check_ownership.return_value = False
 
-        with (
-            pytest.raises(
-                tanjun.CommandError, match="This command is currently in cooldown. Try again <t:1326542469:R>."
-            ),
-            freezegun.freeze_time(datetime.datetime(2012, 1, 14, 12)),
+        with pytest.raises(
+            tanjun.CommandError, match="This command is currently in cooldown. Try again <t:1326542469:R>."
         ):
             await pre_execution(mock_context, cooldowns=mock_cooldown_manager, owner_check=mock_owner_check)
 
@@ -1204,14 +1204,13 @@ class TestCooldownPreExecution:
         pre_execution = tanjun.dependencies.CooldownPreExecution("catgirls yuri", owners_exempt=False)
         mock_context = mock.Mock()
         mock_cooldown_manager = mock.AsyncMock()
-        mock_cooldown_manager.check_cooldown.return_value = datetime.timedelta(seconds=420, milliseconds=69420)
+        mock_cooldown_manager.check_cooldown.return_value = datetime.datetime(
+            2016, 1, 16, 12, 8, 9, 420000, tzinfo=datetime.timezone.utc
+        )
         mock_owner_check = mock.AsyncMock()
 
-        with (
-            pytest.raises(
-                tanjun.CommandError, match="This command is currently in cooldown. Try again <t:1452946089:R>."
-            ),
-            freezegun.freeze_time(datetime.datetime(2016, 1, 16, 12)),
+        with pytest.raises(
+            tanjun.CommandError, match="This command is currently in cooldown. Try again <t:1452946089:R>."
         ):
             await pre_execution(mock_context, cooldowns=mock_cooldown_manager, owner_check=mock_owner_check)
 

--- a/tests/dependencies/test_limiters.py
+++ b/tests/dependencies/test_limiters.py
@@ -1189,7 +1189,9 @@ class TestCooldownPreExecution:
         mock_owner_check.check_ownership.return_value = False
 
         with (
-            pytest.raises(tanjun.CommandError, match="This command is currently in cooldown. Try again <t:1326542469:R>."),
+            pytest.raises(
+                tanjun.CommandError, match="This command is currently in cooldown. Try again <t:1326542469:R>."
+            ),
             freezegun.freeze_time(datetime.datetime(2012, 1, 14, 12)),
         ):
             await pre_execution(mock_context, cooldowns=mock_cooldown_manager, owner_check=mock_owner_check)
@@ -1206,7 +1208,9 @@ class TestCooldownPreExecution:
         mock_owner_check = mock.AsyncMock()
 
         with (
-            pytest.raises(tanjun.CommandError, match="This command is currently in cooldown. Try again <t:1452946089:R>."),
+            pytest.raises(
+                tanjun.CommandError, match="This command is currently in cooldown. Try again <t:1452946089:R>."
+            ),
             freezegun.freeze_time(datetime.datetime(2016, 1, 16, 12)),
         ):
             await pre_execution(mock_context, cooldowns=mock_cooldown_manager, owner_check=mock_owner_check)

--- a/tests/dependencies/test_limiters.py
+++ b/tests/dependencies/test_limiters.py
@@ -1189,7 +1189,7 @@ class TestCooldownPreExecution:
         mock_owner_check.check_ownership.return_value = False
 
         with (
-            pytest.raises(tanjun.CommandError, match="Command is currently in cooldown. Try again <t:1326542469:R>."),
+            pytest.raises(tanjun.CommandError, match="This command is currently in cooldown. Try again <t:1326542469:R>."),
             freezegun.freeze_time(datetime.datetime(2012, 1, 14, 12)),
         ):
             await pre_execution(mock_context, cooldowns=mock_cooldown_manager, owner_check=mock_owner_check)
@@ -1206,7 +1206,7 @@ class TestCooldownPreExecution:
         mock_owner_check = mock.AsyncMock()
 
         with (
-            pytest.raises(tanjun.CommandError, match="Command is currently in cooldown. Try again <t:1452946089:R>."),
+            pytest.raises(tanjun.CommandError, match="This command is currently in cooldown. Try again <t:1452946089:R>."),
             freezegun.freeze_time(datetime.datetime(2016, 1, 16, 12)),
         ):
             await pre_execution(mock_context, cooldowns=mock_cooldown_manager, owner_check=mock_owner_check)


### PR DESCRIPTION
### Summary
Since this format now updates every second on desktop and at least has second precision on the android react native app, it should now be sufficient for this use case.

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
