### PR TITLE
Allow as_(un)loader to be used as a decorator while passing kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Allow `as_loader` and `as_unloader` to be used as decorators while passing keyword-arguments.
 
 ## [2.5.2a1] - 2022-05-16
 ### Added

--- a/dev-requirements/tests.in
+++ b/dev-requirements/tests.in
@@ -4,3 +4,4 @@ pytest-asyncio==0.18.3
 pytest-cov==3
 pytest-timeout==2.1.0
 pytest-xdist==2.5
+typing-extensions==4.2.0

--- a/dev-requirements/tests.txt
+++ b/dev-requirements/tests.txt
@@ -50,3 +50,5 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
+typing-extensions==4.2.0
+    # via -r dev-requirements/tests.in

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -235,17 +235,38 @@ def as_loader(
 
 @typing.overload
 def as_loader(
+    *, standard_impl: typing.Literal[True] = True
+) -> collections.Callable[[collections.Callable[[Client], None]], collections.Callable[[Client], None]]:
+    ...
+
+
+@typing.overload
+def as_loader(
     callback: collections.Callable[[tanjun.Client], None], /, *, standard_impl: typing.Literal[False]
 ) -> collections.Callable[[tanjun.Client], None]:
     ...
 
 
+@typing.overload
 def as_loader(
-    callback: typing.Union[collections.Callable[[Client], None], collections.Callable[[tanjun.Client], None]],
+    *, standard_impl: typing.Literal[False]
+) -> collections.Callable[[collections.Callable[[tanjun.Client], None]], collections.Callable[[tanjun.Client], None]]:
+    ...
+
+
+def as_loader(
+    callback: typing.Union[
+        collections.Callable[[tanjun.Client], None], collections.Callable[[Client], None], None
+    ] = None,
     /,
     *,
     standard_impl: bool = True,
-) -> typing.Union[collections.Callable[[Client], None], collections.Callable[[tanjun.Client], None]]:
+) -> typing.Union[
+    collections.Callable[[tanjun.Client], None],
+    collections.Callable[[Client], None],
+    collections.Callable[[collections.Callable[[Client], None]], collections.Callable[[Client], None]],
+    collections.Callable[[collections.Callable[[tanjun.Client], None]], collections.Callable[[tanjun.Client], None]],
+]:
     """Mark a callback as being used to load Tanjun components from a module.
 
     !!! note
@@ -269,7 +290,13 @@ def as_loader(
     collections.abc.Callable[[tanjun.abc.Client], None]]
         The decorated load callback.
     """
-    return _LoaderDescriptor(callback, standard_impl)
+    if callback:
+        return _LoaderDescriptor(callback, standard_impl)
+
+    def decorator(callback: collections.Callable[[tanjun.Client], None]) -> collections.Callable[[tanjun.Client], None]:
+        return _LoaderDescriptor(callback, standard_impl)
+
+    return decorator
 
 
 @typing.overload
@@ -281,17 +308,38 @@ def as_unloader(
 
 @typing.overload
 def as_unloader(
+    *, standard_impl: typing.Literal[True] = True
+) -> collections.Callable[[collections.Callable[[Client], None]], collections.Callable[[Client], None]]:
+    ...
+
+
+@typing.overload
+def as_unloader(
     callback: collections.Callable[[tanjun.Client], None], /, *, standard_impl: typing.Literal[False]
 ) -> collections.Callable[[tanjun.Client], None]:
     ...
 
 
+@typing.overload
 def as_unloader(
-    callback: typing.Union[collections.Callable[[Client], None], collections.Callable[[tanjun.Client], None]],
+    *, standard_impl: typing.Literal[False]
+) -> collections.Callable[[collections.Callable[[tanjun.Client], None]], collections.Callable[[tanjun.Client], None]]:
+    ...
+
+
+def as_unloader(
+    callback: typing.Union[
+        collections.Callable[[Client], None], collections.Callable[[tanjun.Client], None], None
+    ] = None,
     /,
     *,
     standard_impl: bool = True,
-) -> typing.Union[collections.Callable[[Client], None], collections.Callable[[tanjun.Client], None]]:
+) -> typing.Union[
+    collections.Callable[[Client], None],
+    collections.Callable[[tanjun.Client], None],
+    collections.Callable[[collections.Callable[[Client], None]], collections.Callable[[Client], None]],
+    collections.Callable[[collections.Callable[[tanjun.Client], None]], collections.Callable[[tanjun.Client], None]],
+]:
     """Mark a callback as being used to unload a module's utilities from a client.
 
     !!! note
@@ -317,7 +365,13 @@ def as_unloader(
     collections.abc.Callable[[tanjun.abc.Client], None]]
         The decorated unload callback.
     """
-    return _UnloaderDescriptor(callback, standard_impl)
+    if callback:
+        return _UnloaderDescriptor(callback, standard_impl)
+
+    def decorator(callback: collections.Callable[[tanjun.Client], None]) -> collections.Callable[[tanjun.Client], None]:
+        return _UnloaderDescriptor(callback, standard_impl)
+
+    return decorator
 
 
 ClientCallbackNames = tanjun.ClientCallbackNames

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -48,6 +48,7 @@ from unittest import mock
 
 import hikari
 import pytest
+import typing_extensions
 
 import tanjun
 
@@ -91,6 +92,31 @@ class Test_LoaderDescriptor:
         mock_callback = mock.Mock()
         mock_client = mock.Mock(tanjun.Client)
         descriptor = tanjun.as_loader(mock_callback)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.Client], None])
+        assert isinstance(descriptor, tanjun.clients._LoaderDescriptor)
+
+        result = descriptor.load(mock_client)
+
+        assert result is True
+        mock_callback.assert_called_once_with(mock_client)
+
+    def test_load_when_called_as_decorator(self):
+        mock_callback = mock.Mock()
+        mock_client = mock.Mock(tanjun.Client)
+        descriptor = tanjun.as_loader()(mock_callback)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.Client], None])
+        assert isinstance(descriptor, tanjun.clients._LoaderDescriptor)
+
+        result = descriptor.load(mock_client)
+
+        assert result is True
+        mock_callback.assert_called_once_with(mock_client)
+
+    def test_load_when_called_as_decorator_and_args_passed(self):
+        mock_callback = mock.Mock()
+        mock_client = mock.Mock(tanjun.Client)
+        descriptor = tanjun.as_loader(standard_impl=True)(mock_callback)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.Client], None])
         assert isinstance(descriptor, tanjun.clients._LoaderDescriptor)
 
         result = descriptor.load(mock_client)
@@ -101,6 +127,7 @@ class Test_LoaderDescriptor:
     def test_load_when_must_be_std_and_not_std(self):
         mock_callback = mock.Mock()
         descriptor = tanjun.as_loader(mock_callback)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.Client], None])
         assert isinstance(descriptor, tanjun.clients._LoaderDescriptor)
 
         with pytest.raises(ValueError, match="This loader requires instances of the standard Client implementation"):
@@ -112,6 +139,19 @@ class Test_LoaderDescriptor:
         mock_callback = mock.Mock()
         mock_client = mock.Mock()
         descriptor = tanjun.as_loader(mock_callback, standard_impl=False)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.abc.Client], None])
+        assert isinstance(descriptor, tanjun.clients._LoaderDescriptor)
+
+        result = descriptor.load(mock_client)
+
+        assert result is True
+        mock_callback.assert_called_once_with(mock_client)
+
+    def test_load_when_abc_allowed_and_called_as_decorator(self):
+        mock_callback = mock.Mock()
+        mock_client = mock.Mock()
+        descriptor = tanjun.as_loader(standard_impl=False)(mock_callback)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.abc.Client], None])
         assert isinstance(descriptor, tanjun.clients._LoaderDescriptor)
 
         result = descriptor.load(mock_client)
@@ -165,6 +205,31 @@ class Test_UnloaderDescriptor:
         mock_callback = mock.Mock()
         mock_client = mock.Mock(tanjun.Client)
         descriptor = tanjun.as_unloader(mock_callback)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.Client], None])
+        assert isinstance(descriptor, tanjun.clients._UnloaderDescriptor)
+
+        result = descriptor.unload(mock_client)
+
+        assert result is True
+        mock_callback.assert_called_once_with(mock_client)
+
+    def test_unload_when_called_as_decorator(self):
+        mock_callback = mock.Mock()
+        mock_client = mock.Mock(tanjun.Client)
+        descriptor = tanjun.as_unloader()(mock_callback)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.Client], None])
+        assert isinstance(descriptor, tanjun.clients._UnloaderDescriptor)
+
+        result = descriptor.unload(mock_client)
+
+        assert result is True
+        mock_callback.assert_called_once_with(mock_client)
+
+    def test_unload_called_as_decorator_and_args_passed(self):
+        mock_callback = mock.Mock()
+        mock_client = mock.Mock(tanjun.Client)
+        descriptor = tanjun.as_unloader(standard_impl=True)(mock_callback)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.Client], None])
         assert isinstance(descriptor, tanjun.clients._UnloaderDescriptor)
 
         result = descriptor.unload(mock_client)
@@ -175,6 +240,7 @@ class Test_UnloaderDescriptor:
     def test_unload_when_must_be_std_and_not_std(self):
         mock_callback = mock.Mock()
         descriptor = tanjun.as_unloader(mock_callback)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.Client], None])
         assert isinstance(descriptor, tanjun.clients._UnloaderDescriptor)
 
         with pytest.raises(ValueError, match="This unloader requires instances of the standard Client implementation"):
@@ -186,6 +252,19 @@ class Test_UnloaderDescriptor:
         mock_callback = mock.Mock()
         mock_client = mock.Mock()
         descriptor = tanjun.as_unloader(mock_callback, standard_impl=False)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.abc.Client], None])
+        assert isinstance(descriptor, tanjun.clients._UnloaderDescriptor)
+
+        result = descriptor.unload(mock_client)
+
+        assert result is True
+        mock_callback.assert_called_once_with(mock_client)
+
+    def test_unload_when_abc_allowed_and_called_as_decorator(self):
+        mock_callback = mock.Mock()
+        mock_client = mock.Mock()
+        descriptor = tanjun.as_unloader(standard_impl=False)(mock_callback)
+        typing_extensions.assert_type(descriptor, collections.Callable[[tanjun.abc.Client], None])
         assert isinstance(descriptor, tanjun.clients._UnloaderDescriptor)
 
         result = descriptor.unload(mock_client)


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
