### PR TITLE
Fix slash command parent command tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If no events are passed to `Client.with_listener`/`Component.with_listener` it will now try to infer
   the event type(s) from the callback's type-hints.
 
+### Fixed
+- Slash command parent command tracking.
+
 ## [2.5.3a1] - 2022-07-04
 ### Added
 - Support for sending attachments with `Context.respond`, `CommandError` and

--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -2656,6 +2656,21 @@ class BaseSlashCommand(AppCommand[SlashContext], abc.ABC):
         """
 
     @abc.abstractmethod
+    def copy(self: _T, *, parent: typing.Optional[SlashCommandGroup] = None) -> _T:
+        """Create a copy of this command.
+
+        Parameters
+        ----------
+        parent
+            The parent of the copy.
+
+        Returns
+        -------
+        Self
+            The copy.
+        """
+
+    @abc.abstractmethod
     def set_parent(self: _T, parent: typing.Optional[SlashCommandGroup], /) -> _T:
         raise NotImplementedError
 

--- a/tanjun/commands/slash.py
+++ b/tanjun/commands/slash.py
@@ -1096,7 +1096,7 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
     ) -> _SlashCommandGroupT:
         # <<inherited docstring from tanjun.abc.ExecutableCommand>>.
         inst = super().copy(parent=parent)
-        inst._commands = {name: command.copy() for name, command in self._commands.items()}
+        inst._commands = {name: command.copy(parent=inst) for name, command in self._commands.items()}
         return inst
 
     def add_command(self: _SlashCommandGroupT, command: tanjun.BaseSlashCommand, /) -> _SlashCommandGroupT:


### PR DESCRIPTION
### Summary
Fix slash command parent command tracking
### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Fixes #260

