### PR TITLE
Add shorthand `as` decorator methods to standard command group impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `follow_wrapped` parameter to `Component.with_command`.
-- [MessageCommandGroup.as_sub_command][tanjun.commands.message.MessageCommandGroup.as_sub_command], 
-  [MessageCommandGroup.as_sub_command_group][tanjun.commands.message.MessageCommandGroup.as_sub_command_group], 
-  [SlashCommandGroup.as_sub_command][tanjun.commands.slash.SlashCommandGroup.as_sub_command] and 
+- [MessageCommandGroup.as_sub_command][tanjun.commands.message.MessageCommandGroup.as_sub_command],
+  [MessageCommandGroup.as_sub_command_group][tanjun.commands.message.MessageCommandGroup.as_sub_command_group],
+  [SlashCommandGroup.as_sub_command][tanjun.commands.slash.SlashCommandGroup.as_sub_command] and
   [SlashCommandGroup.make_sub_group][tanjun.commands.slash.SlashCommandGroup.make_sub_group]
   shorthand methods for creating sub-command and sub-command-groups directly on groups.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `follow_wrapped` parameter to `Component.with_command`.
+- [MessageCommandGroup.as_sub_command][tanjun.commands.message.MessageCommandGroup.as_sub_command], 
+  [MessageCommandGroup.as_sub_command_group][tanjun.commands.message.MessageCommandGroup.as_sub_command_group], 
+  [SlashCommandGroup.as_sub_command][tanjun.commands.slash.SlashCommandGroup.as_sub_command] and 
+  [SlashCommandGroup.make_sub_group][tanjun.commands.slash.SlashCommandGroup.make_sub_group]
+  shorthand methods for creating sub-command and sub-command-groups directly on groups.
 
 ### Removed
 - The broken `add_injector` argument from [tanjun.clients.Client.add_component][].

--- a/tanjun/commands/menu.py
+++ b/tanjun/commands/menu.py
@@ -129,6 +129,10 @@ def as_message_menu(
         the command should be bulk set by [tanjun.Client.declare_global_commands][]
         or when `declare_global_commands` is True
 
+    !!! warning
+        `default_member_permissions`, "dm_enabled" and `is_global` are
+        ignored for commands within slash command groups.
+
     !!! note
         If you want your first response to be ephemeral while using
         `always_defer`, you must set `default_to_ephemeral` to `True`.
@@ -216,6 +220,10 @@ def as_user_menu(
         Under the standard implementation, `is_global` is used to determine whether
         the command should be bulk set by [tanjun.Client.declare_global_commands][]
         or when `declare_global_commands` is True
+
+    !!! warning
+        `default_member_permissions`, "dm_enabled" and `is_global` are
+        ignored for commands within slash command groups.
 
     !!! note
         If you want your first response to be ephemeral while using
@@ -367,6 +375,10 @@ class MenuCommand(base.PartialCommand[tanjun.MenuContext], tanjun.MenuCommand[_M
             Under the standard implementation, `is_global` is used to determine whether
             the command should be bulk set by [tanjun.Client.declare_global_commands][]
             or when `declare_global_commands` is True
+
+        !!! warning
+            `default_member_permissions`, "dm_enabled" and `is_global` are
+            ignored for commands within slash command groups.
 
         !!! note
             If you want your first response to be ephemeral while using

--- a/tanjun/commands/menu.py
+++ b/tanjun/commands/menu.py
@@ -129,10 +129,6 @@ def as_message_menu(
         the command should be bulk set by [tanjun.Client.declare_global_commands][]
         or when `declare_global_commands` is True
 
-    !!! warning
-        `default_member_permissions`, "dm_enabled" and `is_global` are
-        ignored for commands within slash command groups.
-
     !!! note
         If you want your first response to be ephemeral while using
         `always_defer`, you must set `default_to_ephemeral` to `True`.
@@ -220,10 +216,6 @@ def as_user_menu(
         Under the standard implementation, `is_global` is used to determine whether
         the command should be bulk set by [tanjun.Client.declare_global_commands][]
         or when `declare_global_commands` is True
-
-    !!! warning
-        `default_member_permissions`, "dm_enabled" and `is_global` are
-        ignored for commands within slash command groups.
 
     !!! note
         If you want your first response to be ephemeral while using
@@ -375,10 +367,6 @@ class MenuCommand(base.PartialCommand[tanjun.MenuContext], tanjun.MenuCommand[_M
             Under the standard implementation, `is_global` is used to determine whether
             the command should be bulk set by [tanjun.Client.declare_global_commands][]
             or when `declare_global_commands` is True
-
-        !!! warning
-            `default_member_permissions`, "dm_enabled" and `is_global` are
-            ignored for commands within slash command groups.
 
         !!! note
             If you want your first response to be ephemeral while using

--- a/tanjun/commands/message.py
+++ b/tanjun/commands/message.py
@@ -527,9 +527,7 @@ class MessageCommandGroup(MessageCommand[_CommandCallbackSigT], tanjun.MessageCo
             The decorator callback used to make a [tanjun.MessageCommand][].
 
             This can either wrap a raw command callback or another callable command instance
-            (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][], [tanjun.SlashCommand][])
-            and will manage loading the other command into a component when using
-            [tanjun.Component.load_from_scope][].
+            (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][], [tanjun.SlashCommand][]).
         """
 
         def decorator(
@@ -564,9 +562,7 @@ class MessageCommandGroup(MessageCommand[_CommandCallbackSigT], tanjun.MessageCo
             The decorator callback used to make a [tanjun.MessageCommandGroup][].
 
             This can either wrap a raw command callback or another callable command instance
-            (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][], [tanjun.SlashCommand][])
-            and will manage loading the other command into a component when using
-            [tanjun.Component.load_from_scope][].
+            (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][], [tanjun.SlashCommand][]).
         """
 
         def decorator(

--- a/tanjun/commands/message.py
+++ b/tanjun/commands/message.py
@@ -524,7 +524,7 @@ class MessageCommandGroup(MessageCommand[_CommandCallbackSigT], tanjun.MessageCo
         Returns
         -------
         collections.abc.Callable[[tanjun.abc.CommandCallbackSig], MessageCommand]
-            The decorator callback used to make a [tanjun.MessageCommand][].
+            The decorator callback used to make a sub-command.
 
             This can either wrap a raw command callback or another callable command instance
             (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][], [tanjun.SlashCommand][]).
@@ -559,7 +559,7 @@ class MessageCommandGroup(MessageCommand[_CommandCallbackSigT], tanjun.MessageCo
         Returns
         -------
         collections.abc.Callable[[tanjun.abc.CommandCallbackSig], MessageCommand]
-            The decorator callback used to make a [tanjun.MessageCommandGroup][].
+            The decorator callback used to make a sub-command group.
 
             This can either wrap a raw command callback or another callable command instance
             (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][], [tanjun.SlashCommand][]).

--- a/tanjun/commands/message.py
+++ b/tanjun/commands/message.py
@@ -57,6 +57,7 @@ if typing.TYPE_CHECKING:
     _MessageCommandGroupT = typing.TypeVar("_MessageCommandGroupT", bound="MessageCommandGroup[typing.Any]")
 
 _CommandCallbackSigT = typing.TypeVar("_CommandCallbackSigT", bound=tanjun.CommandCallbackSig)
+_OtherCallbackSigT = typing.TypeVar("_OtherCallbackSigT", bound=tanjun.CommandCallbackSig)
 _EMPTY_DICT: typing.Final[dict[typing.Any, typing.Any]] = {}
 _EMPTY_HOOKS: typing.Final[hooks_.Hooks[typing.Any]] = hooks_.Hooks()
 
@@ -507,6 +508,75 @@ class MessageCommandGroup(MessageCommand[_CommandCallbackSigT], tanjun.MessageCo
         command.set_parent(self)
         self._commands.append(command)
         return self
+
+    def as_message_command(self, name: str, /, *names: str, validate_arg_keys: bool = True) -> _ResultProto:
+        """Build a message command in this group from a decorated callback.
+
+        Parameters
+        ----------
+        name
+            The command name.
+        *names
+            Variable positional arguments of other names for the command.
+        validate_arg_keys
+            Whether to validate that option keys match the command callback's signature.
+
+        Returns
+        -------
+        collections.abc.Callable[[tanjun.abc.CommandCallbackSig], MessageCommand]
+            The decorator callback used to make a [tanjun.MessageCommand][].
+
+            This can either wrap a raw command callback or another callable command instance
+            (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][], [tanjun.SlashCommand][])
+            and will manage loading the other command into a component when using
+            [tanjun.Component.load_from_scope][].
+        """
+
+        def decorator(
+            callback: typing.Union[_OtherCallbackSigT, _CommandT[_OtherCallbackSigT]], /
+        ) -> MessageCommand[_OtherCallbackSigT]:
+            return self.with_command(as_message_command(name, *names, validate_arg_keys=validate_arg_keys)(callback))
+
+        return decorator
+
+    def as_message_command_group(
+        self, name: str, /, *names: str, strict: bool = False, validate_arg_keys: bool = True
+    ) -> _GroupResultProto:
+        """Build a message command group in this group from a decorated callback.
+
+        Parameters
+        ----------
+        name
+            The command name.
+        *names
+            Variable positional arguments of other names for the command.
+        strict
+            Whether this command group should only allow commands without spaces in their names.
+
+            This allows for a more optimised command search pattern to be used and
+            enforces that command names are unique to a single command within the group.
+        validate_arg_keys
+            Whether to validate that option keys match the command callback's signature.
+
+        Returns
+        -------
+        collections.abc.Callable[[tanjun.abc.CommandCallbackSig], MessageCommand]
+            The decorator callback used to make a [tanjun.MessageCommandGroup][].
+
+            This can either wrap a raw command callback or another callable command instance
+            (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][], [tanjun.SlashCommand][])
+            and will manage loading the other command into a component when using
+            [tanjun.Component.load_from_scope][].
+        """
+
+        def decorator(
+            callback: typing.Union[_OtherCallbackSigT, _CommandT[_OtherCallbackSigT]], /
+        ) -> MessageCommandGroup[_OtherCallbackSigT]:
+            return self.with_command(
+                as_message_command_group(name, *names, strict=strict, validate_arg_keys=validate_arg_keys)(callback)
+            )
+
+        return decorator
 
     def remove_command(
         self: _MessageCommandGroupT, command: tanjun.MessageCommand[typing.Any], /

--- a/tanjun/commands/message.py
+++ b/tanjun/commands/message.py
@@ -509,7 +509,7 @@ class MessageCommandGroup(MessageCommand[_CommandCallbackSigT], tanjun.MessageCo
         self._commands.append(command)
         return self
 
-    def as_message_command(self, name: str, /, *names: str, validate_arg_keys: bool = True) -> _ResultProto:
+    def as_sub_command(self, name: str, /, *names: str, validate_arg_keys: bool = True) -> _ResultProto:
         """Build a message command in this group from a decorated callback.
 
         Parameters
@@ -537,7 +537,7 @@ class MessageCommandGroup(MessageCommand[_CommandCallbackSigT], tanjun.MessageCo
 
         return decorator
 
-    def as_message_command_group(
+    def as_sub_command_group(
         self, name: str, /, *names: str, strict: bool = False, validate_arg_keys: bool = True
     ) -> _GroupResultProto:
         """Build a message command group in this group from a decorated callback.

--- a/tanjun/commands/slash.py
+++ b/tanjun/commands/slash.py
@@ -1185,7 +1185,7 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
         Returns
         -------
         collections.abc.Callable[[tanjun.abc.CommandCallbackSig], SlashCommand]
-            The decorator callback used to make a [tanjun.SlashCommand][].
+            The decorator callback used to make a sub-command.
 
             This can either wrap a raw command callback or another callable command instance
             (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][] [tanjun.SlashCommand][]).
@@ -1218,7 +1218,7 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
         *,
         default_to_ephemeral: typing.Optional[bool] = None,
     ) -> SlashCommandGroup:
-        r"""Create a sub command group in this group.
+        r"""Create a sub-command group in this group.
 
         !!! note
             Unlike message command groups, slash command groups cannot
@@ -1242,7 +1242,7 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
         Returns
         -------
         SlashCommandGroup
-            The sub command group.
+            The created sub-command group.
 
         Raises
         ------

--- a/tanjun/commands/slash.py
+++ b/tanjun/commands/slash.py
@@ -118,6 +118,10 @@ def slash_command_group(
         Unlike message command groups, slash command groups cannot
         be callable functions themselves.
 
+    !!! warning
+        `default_member_permissions`, "dm_enabled" and `is_global` are
+        ignored for command groups within other slash command groups.
+
     !!! note
         Under the standard implementation, `is_global` is used to determine whether
         the command should be bulk set by [tanjun.Client.declare_global_commandsadd_command
@@ -230,7 +234,8 @@ def as_slash_command(
         or when `declare_global_commands` is True
 
     !!! warning
-        `is_global` is ignored for commands within slash command groups.
+        `default_member_permissions`, "dm_enabled" and `is_global` are
+        ignored for commands within slash command groups.
 
     !!! note
         If you want your first response to be ephemeral while using
@@ -1003,6 +1008,10 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
             whether the command should be bulk set by [tanjun.Client.declare_global_commands][]
             or when `declare_global_commands` is True
 
+        !!! warning
+            `default_member_permissions`, "dm_enabled" and `is_global` are
+            ignored for commands groups within another slash command groups.
+
         Parameters
         ----------
         name
@@ -1288,7 +1297,8 @@ class SlashCommand(BaseSlashCommand, tanjun.SlashCommand[_CommandCallbackSigT]):
             or when `declare_global_commands` is True
 
         !!! warning
-            `is_global` is ignored for commands within slash command groups.
+            `default_member_permissions`, "dm_enabled" and `is_global` are
+            ignored for commands within slash command groups.
 
         !!! note
             If you want your first response to be ephemeral while using

--- a/tanjun/commands/slash.py
+++ b/tanjun/commands/slash.py
@@ -1137,7 +1137,7 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
         self._commands[command.name] = command
         return self
 
-    def as_slash_command(
+    def as_sub_command(
         self,
         name: str,
         description: str,
@@ -1209,6 +1209,51 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
                 validate_arg_keys=validate_arg_keys,
             )(callback)
         )
+
+    def make_sub_group(
+        self,
+        name: str,
+        description: str,
+        /,
+        *,
+        default_to_ephemeral: typing.Optional[bool] = None,
+    ) -> SlashCommandGroup:
+        r"""Create a sub command group in this group.
+
+        !!! note
+            Unlike message command groups, slash command groups cannot
+            be callable functions themselves.
+
+        Parameters
+        ----------
+        name
+            The name of the command group.
+
+            This must match the regex `^[\w-]{1,32}$` in Unicode mode and be lowercase.
+        description
+            The description of the command group.
+        default_to_ephemeral
+            Whether this command's responses should default to ephemeral unless flags
+            are set to override this.
+
+            If this is left as [None][] then the default set on the parent command(s),
+            component or client will be in effect.
+
+        Returns
+        -------
+        SlashCommandGroup
+            The sub command group.
+
+        Raises
+        ------
+        ValueError
+            Raises a value error for any of the following reasons:
+
+            * If the command name doesn't match the regex `^[\w-]{1,32}$` (Unicode mode).
+            * If the command name has uppercase characters.
+            * If the description is over 100 characters long.
+        """
+        return self.with_command(slash_command_group(name, description, default_to_ephemeral=default_to_ephemeral))
 
     def remove_command(self: _SlashCommandGroupT, command: tanjun.BaseSlashCommand, /) -> _SlashCommandGroupT:
         """Remove a command from this group.

--- a/tanjun/commands/slash.py
+++ b/tanjun/commands/slash.py
@@ -1137,6 +1137,81 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
         self._commands[command.name] = command
         return self
 
+    def as_slash_command(
+        self,
+        name: str,
+        description: str,
+        /,
+        *,
+        always_defer: bool = False,
+        default_to_ephemeral: typing.Optional[bool] = None,
+        sort_options: bool = True,
+        validate_arg_keys: bool = True,
+    ) -> collections.Callable[[_CommandCallbackSigT], SlashCommand[_CommandCallbackSigT]]:
+        r"""Build a [tanjun.SlashCommand][] in this command group by decorating a function.
+
+        !!! note
+            If you want your first response to be ephemeral while using
+            `always_defer`, you must set `default_to_ephemeral` to `True`.
+
+        Parameters
+        ----------
+        name
+            The command's name.
+
+            This must match the regex `^[\w-]{1,32}` in Unicode mode and be lowercase.
+        description
+            The command's description.
+            This should be inclusively between 1-100 characters in length.
+        always_defer
+            Whether the contexts this command is executed with should always be deferred
+            before being passed to the command's callback.
+        default_to_ephemeral
+            Whether this command's responses should default to ephemeral unless flags
+            are set to override this.
+
+            If this is left as [None][] then the default set on the parent command(s),
+            component or client will be in effect.
+        sort_options
+            Whether this command should sort its set options based on whether
+            they're required.
+
+            If this is [True][] then the options are re-sorted to meet the requirement
+            from Discord that required command options be listed before optional
+            ones.
+        validate_arg_keys
+            Whether to validate that option keys match the command callback's signature.
+
+        Returns
+        -------
+        collections.abc.Callable[[tanjun.abc.CommandCallbackSig], SlashCommand]
+            The decorator callback used to make a [tanjun.SlashCommand][].
+
+            This can either wrap a raw command callback or another callable command instance
+            (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][] [tanjun.SlashCommand][])
+            and will manage loading the other command into a component when using
+            [tanjun.Component.load_from_scope][].
+
+        Raises
+        ------
+        ValueError
+            Raises a value error for any of the following reasons:
+
+            * If the command name doesn't match the regex `^[\w-]{1,32}$` (Unicode mode).
+            * If the command name has uppercase characters.
+            * If the description is over 100 characters long.
+        """
+        return lambda callback: self.with_command(
+            as_slash_command(
+                name,
+                description,
+                always_defer=always_defer,
+                default_to_ephemeral=default_to_ephemeral,
+                sort_options=sort_options,
+                validate_arg_keys=validate_arg_keys,
+            )(callback)
+        )
+
     def remove_command(self: _SlashCommandGroupT, command: tanjun.BaseSlashCommand, /) -> _SlashCommandGroupT:
         """Remove a command from this group.
 

--- a/tanjun/commands/slash.py
+++ b/tanjun/commands/slash.py
@@ -1188,9 +1188,7 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
             The decorator callback used to make a [tanjun.SlashCommand][].
 
             This can either wrap a raw command callback or another callable command instance
-            (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][] [tanjun.SlashCommand][])
-            and will manage loading the other command into a component when using
-            [tanjun.Component.load_from_scope][].
+            (e.g. [tanjun.MenuCommand][], [tanjun.MessageCommand][] [tanjun.SlashCommand][]).
 
         Raises
         ------

--- a/tanjun/hooks.py
+++ b/tanjun/hooks.py
@@ -357,7 +357,7 @@ AnyHooks = Hooks[tanjun.Context]
 """
 
 MenuHooks = Hooks[tanjun.MenuContext]
-"""Hooks that can be used with a message context.
+"""Hooks that can be used with a menu context.
 
 !!! note
     This is shorthand for `Hooks[tanjun.abc.MenuContext]`.

--- a/tests/commands/test_message.py
+++ b/tests/commands/test_message.py
@@ -533,11 +533,11 @@ class TestMessageCommandGroup:
 
         command_group = tanjun.MessageCommandGroup(mock.Mock(), "meow")
 
-        result = command_group.as_sub_command_group("now", "viet", "nam", strict=True, validate_arg_keys=False)(
+        result = command_group.as_sub_command_group("now", "viet", "namm", strict=True, validate_arg_keys=False)(
             mock_callback
         )
 
-        assert result.names == ["now", "viet", "nam"]
+        assert result.names == ["now", "viet", "namm"]
         assert result.is_strict is True
         assert result._arg_names is None
 

--- a/tests/commands/test_message.py
+++ b/tests/commands/test_message.py
@@ -493,6 +493,54 @@ class TestMessageCommandGroup:
         ):
             command_group.add_command(mock.Mock(names={"aaa", "dsaasd"}))
 
+    def test_as_sub_command(self):
+        async def mock_callback(ctx: tanjun.abc.MessageContext) -> None:
+            raise NotImplementedError
+
+        command_group = tanjun.MessageCommandGroup(mock.Mock(), "meow")
+
+        result = command_group.as_sub_command("neco")(mock_callback)
+
+        assert result.names == ["neco"]
+        assert result._arg_names is not None
+
+    def test_as_sub_command_with_optional_args(self):
+        async def mock_callback(ctx: tanjun.abc.MessageContext) -> None:
+            raise NotImplementedError
+
+        command_group = tanjun.MessageCommandGroup(mock.Mock(), "meow")
+
+        result = command_group.as_sub_command("neco", "nyan", validate_arg_keys=False)(mock_callback)
+
+        assert result.names == ["neco", "nyan"]
+        assert result._arg_names is None
+
+    def test_as_sub_command_group(self):
+        async def mock_callback(ctx: tanjun.abc.MessageContext) -> None:
+            raise NotImplementedError
+
+        command_group = tanjun.MessageCommandGroup(mock.Mock(), "meow")
+
+        result = command_group.as_sub_command_group("n")(mock_callback)
+
+        assert result.names == ["n"]
+        assert result.is_strict is False
+        assert result._arg_names is not None
+
+    def test_as_sub_command_group_with_optional_args(self):
+        async def mock_callback(ctx: tanjun.abc.MessageContext) -> None:
+            raise NotImplementedError
+
+        command_group = tanjun.MessageCommandGroup(mock.Mock(), "meow")
+
+        result = command_group.as_sub_command_group("now", "viet", "nam", strict=True, validate_arg_keys=False)(
+            mock_callback
+        )
+
+        assert result.names == ["now", "viet", "nam"]
+        assert result.is_strict is True
+        assert result._arg_names is None
+
     def test_remove_command(self):
         mock_command = mock.Mock()
         command_group = tanjun.MessageCommandGroup[typing.Any](mock.Mock(), "a", "b").add_command(mock_command)

--- a/tests/commands/test_slash.py
+++ b/tests/commands/test_slash.py
@@ -863,6 +863,69 @@ class TestSlashCommandGroup:
         with pytest.raises(ValueError, match="Cannot add a slash command group to a nested slash command group"):
             command_group.add_command(mock.Mock(tanjun.abc.SlashCommandGroup))
 
+    def test_as_sub_command(self):
+        async def mock_callback(ctx: tanjun.abc.SlashContext) -> None:
+            raise NotImplementedError
+
+        command_group = tanjun.SlashCommandGroup("nyaa", "yippe")
+
+        result = command_group.as_sub_command("nameth", "meowed")(mock_callback)
+
+        assert isinstance(result, tanjun.SlashCommand)
+        assert result.name == "nameth"
+        assert result.description == "meowed"
+        assert result._always_defer is False
+        assert result.defaults_to_ephemeral is None
+        assert result._builder._sort_options is True
+        assert result._arg_names is not None
+        assert result in command_group.commands
+
+    def test_as_sub_command_with_optional_args(self):
+        async def mock_callback(ctx: tanjun.abc.SlashContext) -> None:
+            raise NotImplementedError
+
+        command_group = tanjun.SlashCommandGroup("nyaa", "yippe")
+
+        result = command_group.as_sub_command(
+            "nameth",
+            "meowed",
+            always_defer=True,
+            default_to_ephemeral=True,
+            sort_options=False,
+            validate_arg_keys=False,
+        )(mock_callback)
+
+        assert isinstance(result, tanjun.SlashCommand)
+        assert result.name == "nameth"
+        assert result.description == "meowed"
+        assert result._always_defer is True
+        assert result.defaults_to_ephemeral is True
+        assert result._builder._sort_options is False
+        assert result._arg_names is None
+        assert result in command_group.commands
+
+    def test_make_sub_group(self):
+        command_group = tanjun.SlashCommandGroup("nyaa", "yippe")
+
+        result = command_group.make_sub_group("cats", "for life")
+
+        assert isinstance(result, tanjun.SlashCommandGroup)
+        assert result.name == "cats"
+        assert result.description == "for life"
+        assert result.defaults_to_ephemeral is None
+        assert result in command_group.commands
+
+    def test_make_sub_group_with_optional_args(self):
+        command_group = tanjun.SlashCommandGroup("nyaa", "yippe")
+
+        result = command_group.make_sub_group("lovely", "cats", default_to_ephemeral=True)
+
+        assert isinstance(result, tanjun.SlashCommandGroup)
+        assert result.name == "lovely"
+        assert result.description == "cats"
+        assert result.defaults_to_ephemeral is True
+        assert result in command_group.commands
+
     def test_remove_command(self):
         mock_sub_command = mock.Mock(tanjun.abc.SlashCommand)
         command_group = tanjun.SlashCommandGroup("yee", "nsoosos").set_parent(mock.Mock()).add_command(mock_sub_command)


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
