### PR TITLE
Add support for optional positional message args to annotation parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for marking positional message arguments as option when using annotation parsing.
 
 ## [2.6.3a1] - 2022-09-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Support for marking positional message arguments as option when using annotation parsing.
+- Support for marking positional message arguments as optional when using annotation parsing.
 
 ## [2.6.3a1] - 2022-09-17
 ### Added

--- a/tanjun/annotations.py
+++ b/tanjun/annotations.py
@@ -242,7 +242,7 @@ class Choices(_ConfigIdentifier, metaclass=_ChoicesMeta):
         return self._choices
 
     def set_config(self, config: _ArgConfig, /) -> None:
-        config.choices = self.choices
+        config.choices = self._choices
 
 
 class _ConvertedMeta(abc.ABCMeta):
@@ -294,7 +294,7 @@ class Converted(_ConfigIdentifier, metaclass=_ConvertedMeta):
         return self._converters
 
     def set_config(self, config: _ArgConfig, /) -> None:
-        config.converters = self.converters
+        config.converters = self._converters
 
 
 Color = Converted[conversion.to_color]
@@ -395,8 +395,8 @@ class Flag(_ConfigIdentifier):
         if config.default is parsing.UNDEFINED:
             raise ValueError(f"Flag argument {config.key!r} must have a default")
 
-        config.aliases = self.aliases
-        config.empty_value = self.empty_value
+        config.aliases = self._aliases
+        config.empty_value = self._empty_value
         config.is_positional = False
 
 
@@ -570,7 +570,7 @@ class Max(_ConfigIdentifier, metaclass=_MaxMeta):
         return self._value
 
     def set_config(self, config: _ArgConfig, /) -> None:
-        config.max_value = self.value
+        config.max_value = self._value
 
 
 class _MinMeta(abc.ABCMeta):
@@ -631,7 +631,7 @@ class Min(_ConfigIdentifier, metaclass=_MinMeta):
         return self._value
 
     def set_config(self, config: _ArgConfig, /) -> None:
-        config.min_value = self.value
+        config.min_value = self._value
 
 
 class Name(_ConfigIdentifier):
@@ -699,8 +699,8 @@ class Name(_ConfigIdentifier):
         return self._slash_name
 
     def set_config(self, config: _ArgConfig, /) -> None:
-        config.slash_name = self.slash_name or config.slash_name
-        config.message_name = self.message_name or config.message_name
+        config.slash_name = self._slash_name or config.slash_name
+        config.message_name = self._message_name or config.message_name
 
 
 class _RangedMeta(abc.ABCMeta):
@@ -769,8 +769,8 @@ class Ranged(_ConfigIdentifier, metaclass=_RangedMeta):
         return self._min_value
 
     def set_config(self, config: _ArgConfig, /) -> None:
-        config.max_value = self.max_value
-        config.min_value = self.min_value
+        config.max_value = self._max_value
+        config.min_value = self._min_value
 
 
 # _MESSAGE_ID_ONLY
@@ -870,7 +870,7 @@ class SnowflakeOr(_ConfigIdentifier, metaclass=_SnowflakeOrMeta):
         return self._parse_id
 
     def set_config(self, config: _ArgConfig, /) -> None:
-        config.snowflake_converter = self.parse_id
+        config.snowflake_converter = self._parse_id
 
 
 class _TypeOverride(_ConfigIdentifier):
@@ -879,12 +879,8 @@ class _TypeOverride(_ConfigIdentifier):
     def __init__(self, override: type[typing.Any], /) -> None:
         self._override = override
 
-    @property
-    def override(self) -> type[typing.Any]:
-        return self._override
-
     def set_config(self, config: _ArgConfig, /) -> None:
-        config.option_type = self.override
+        config.option_type = self._override
 
 
 class _TheseChannelsMeta(abc.ABCMeta):
@@ -928,7 +924,7 @@ class TheseChannels(_ConfigIdentifier, metaclass=_TheseChannelsMeta):
         return self._channel_types
 
     def set_config(self, config: _ArgConfig, /) -> None:
-        config.channel_types = self.channel_types
+        config.channel_types = self._channel_types
 
 
 def _ensure_value(name: str, type_: type[_T], value: typing.Optional[typing.Any]) -> typing.Optional[_T]:

--- a/tanjun/annotations.py
+++ b/tanjun/annotations.py
@@ -378,7 +378,6 @@ class Positional(_ConfigIdentifier, metaclass=_PositionalMeta):
 
         config.is_positional = True
 
-
     """Mark an argument as a flag/option for message command parsing.
 
     This indicates that the argument should be specified by name (e.g. `--name`)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -46,6 +46,120 @@ import tanjun
 from tanjun import annotations
 
 
+class TestChoices:
+    def test_choices_property(self):
+        choices = annotations.Choices({"beep": "boop", "cat": "girls", "are": "sexy"})
+
+        assert choices.choices == {"beep": "boop", "cat": "girls", "are": "sexy"}
+
+    def test_choices_property_for_sequence(self):
+        choices = annotations.Choices([("ok", "no"), ("meow", "nyaa")])
+
+        assert choices.choices == {"ok": "no", "meow": "nyaa"}
+
+
+class TestConverted:
+    def test_converters_property(self):
+        converter_1 = mock.Mock()
+        converter_2 = mock.Mock()
+        converter_3 = mock.AsyncMock()
+        converters = annotations.Converted(converter_1, converter_2, converter_3)
+
+        assert converters.converters == [converter_1, converter_2, converter_3]
+
+
+class TestFlag:
+    def test_properties(self):
+        flag = annotations.Flag(aliases=("yeet", "meat", "meow"), default=123321, empty_value="nom")
+
+        assert flag.aliases == ("yeet", "meat", "meow")
+        assert flag.default == 123321
+        assert flag.empty_value == "nom"
+
+    def test_properties_with_default_values(self):
+        flag = annotations.Flag()
+
+        assert flag.aliases is None
+        assert flag.default is tanjun.parsing.UNDEFINED
+        assert flag.empty_value is tanjun.parsing.UNDEFINED
+
+
+class TestPositional:
+    def test_default_property(self):
+        positional = annotations.Positional(default=69420)
+
+        assert positional.default == 69420
+
+    def test_default_property_with_default(self):
+        positional = annotations.Positional()
+
+        assert positional.default is tanjun.parsing.UNDEFINED
+
+
+class TestMax:
+    def test_value_property(self):
+        max_ = annotations.Max(32221)
+
+        assert max_.value == 32221
+
+
+class TestMin:
+    def test_value_property(self):
+        min_ = annotations.Min(3112222)
+
+        assert min_.value == 3112222
+
+
+class TestName:
+    def test_properties_when_both(self):
+        names = annotations.Name("meow_ok")
+
+        assert names.message_name == "--meow-ok"
+        assert names.slash_name == "meow_ok"
+
+    def test_properties_with_defaults(self):
+        names = annotations.Name()
+        assert names.message_name is None
+        assert names.slash_name is None
+
+    def test_properties_when_different(self):
+        names = annotations.Name(message="--__echo", slash="__-nyaa")
+
+        assert names.message_name == "--__echo"
+        assert names.slash_name == "__-nyaa"
+
+
+class TestRanged:
+    def test_properties(self):
+        ranged = annotations.Ranged(123, 543)
+
+        assert ranged.max_value == 543
+        assert ranged.min_value == 123
+
+
+class TestSnowflakeOr:
+    def test_parser_id_property(self):
+        mock_callback = mock.Mock()
+
+        snowflake_or = annotations.SnowflakeOr(parse_id=mock_callback)
+
+        assert snowflake_or.parse_id is mock_callback
+
+    def test_parser_id_property_with_default(self):
+        snowflake_or = annotations.SnowflakeOr()
+
+        assert snowflake_or.parse_id == tanjun.conversion.parse_snowflake
+
+
+class TestTheseChannels:
+    def test_channel_types_property(self):
+        these_channels = annotations.TheseChannels(
+            hikari.DMChannel, hikari.GuildChannel, hikari.ChannelType.GUILD_STAGE
+        )
+
+        assert these_channels.channel_types == (hikari.DMChannel, hikari.GuildChannel, hikari.ChannelType.GUILD_STAGE)
+
+
 def test_where_no_signature():
     with pytest.raises(ValueError, match=".+"):
         inspect.Signature.from_callable(int)
@@ -222,7 +336,7 @@ def test_when_follow_wrapping_and_wrapping_unsupported_command():
 
 
 def test_with_with_std_range():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -279,7 +393,7 @@ def test_with_with_std_range():
 
 
 def test_with_with_backwards_std_range():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -336,7 +450,7 @@ def test_with_with_backwards_std_range():
 
 
 def test_with_std_slice():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -393,7 +507,7 @@ def test_with_std_slice():
 
 
 def test_with_backwards_std_slice():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -566,7 +680,7 @@ def test_choices(
     choices: collections.Sequence[_ChoiceT],
     result: collections.Sequence[hikari.CommandChoice],
 ):
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     async def callback(
         ctx: tanjun.abc.Context,
@@ -665,7 +779,7 @@ def test_with_generic_float_choices():
         Blam = 432.123
         Ok = 43.34
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -754,7 +868,7 @@ def test_with_generic_int_choices():
         Batman = 123
         Bazman = 0
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -842,7 +956,7 @@ def test_with_generic_str_choices():
         Sis = "pls"
         Catgirl = "uwu"
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1187,7 +1301,7 @@ def test_with_flag_missing_default():
 
 
 def test_with_positional():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("name")
     @tanjun.as_slash_command("boop", "description")
     async def callback(
@@ -1222,7 +1336,7 @@ def test_with_positional():
 
 
 def test_with_poisitional_explicit_default():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("noot")
     @tanjun.as_slash_command("boom", "description 2")
     async def callback(
@@ -1257,7 +1371,7 @@ def test_with_poisitional_explicit_default():
 
 
 def test_with_positional_passed_default():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("nom")
     @tanjun.as_slash_command("blam", "description 3")
     async def callback(
@@ -1292,7 +1406,7 @@ def test_with_positional_passed_default():
 
 
 def test_with_greedy():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
@@ -1313,7 +1427,7 @@ def test_with_greedy():
 
 
 def test_with_generic_greedy():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
@@ -1346,7 +1460,7 @@ def test_with_max(
     raw_type: type[typing.Any],
     option_type: hikari.OptionType,
 ):
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1427,7 +1541,7 @@ def test_with_max(
 def test_with_generic_max(
     value: typing.Union[int, float], converter: typing.Union[type[int], type[float]], option_type: hikari.OptionType
 ):
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1601,7 +1715,7 @@ def test_with_min(
     option_type: hikari.OptionType,
     value: typing.Union[int, float],
 ):
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1682,7 +1796,7 @@ def test_with_min(
 def test_with_generic_min(
     value: typing.Union[int, float], converter: typing.Union[type[int], type[float]], option_type: hikari.OptionType
 ):
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1844,7 +1958,7 @@ def test_with_min_when_int_for_float():
 
 
 def test_with_overridden_name():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1919,7 +2033,7 @@ def test_with_overridden_name():
 
 
 def test_with_individually_overridden_name():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1996,7 +2110,7 @@ def test_with_individually_overridden_name():
 
 
 def test_with_overridden_slash_name():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -2071,7 +2185,7 @@ def test_with_overridden_slash_name():
 
 
 def test_with_overridden_message_name():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -2118,7 +2232,7 @@ def test_with_overridden_message_name():
 
 
 def test_with_ranged():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -2189,7 +2303,7 @@ def test_with_generic_ranged(
     converter: typing.Union[type[float], type[int]],
     option_type: hikari.OptionType,
 ):
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -2266,7 +2380,7 @@ def test_with_generic_ranged(
 def test_with_snowflake_or():
     mock_callback = mock.Mock()
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2342,7 +2456,7 @@ def test_with_snowflake_or():
 
 
 def test_with_generic_snowflake_or_for_channel():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2418,7 +2532,7 @@ def test_with_generic_snowflake_or_for_channel():
 
 
 def test_with_generic_snowflake_or_for_member():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2494,7 +2608,7 @@ def test_with_generic_snowflake_or_for_member():
 
 
 def test_with_generic_snowflake_or_for_mentionable():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2570,7 +2684,7 @@ def test_with_generic_snowflake_or_for_mentionable():
 
 
 def test_with_generic_snowflake_or_for_role():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2646,7 +2760,7 @@ def test_with_generic_snowflake_or_for_role():
 
 
 def test_with_generic_snowflake_or_for_user():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2722,7 +2836,7 @@ def test_with_generic_snowflake_or_for_user():
 
 
 def test_with_generic_snowflake_or():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1096,17 +1096,19 @@ def test_with_generic_converted():
 def test_with_flag():
     empty_value = mock.Mock()
 
-    @annotations.with_annotated_args
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("meow")
+    @tanjun.as_slash_command("beep", "boop")
     async def callback(
         ctx: tanjun.abc.MessageContext,
         eep: typing.Annotated[
-            annotations.Int, annotations.Flag(aliases=("--hi", "--bye"), empty_value=empty_value, default=1231)
+            annotations.Int, annotations.Flag(aliases=("--hi", "--bye"), empty_value=empty_value, default=1231), "b"
         ] = 545454,
     ) -> None:
         ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
+    assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
     assert len(callback.parser.arguments) == 0
     assert len(callback.parser.options) == 1
     option = callback.parser.options[0]
@@ -1119,17 +1121,32 @@ def test_with_flag():
     assert option.min_value is None
     assert option.max_value is None
 
+    assert callback.wrapped_command.build().options == [
+        hikari.CommandOption(
+            type=hikari.OptionType.INTEGER,
+            name="eep",
+            channel_types=None,
+            description="b",
+            is_required=False,
+        )
+    ]
+    assert len(callback.wrapped_command._tracked_options) == 1
+    option = callback.wrapped_command._tracked_options["eep"]
+    assert option.default == 1231
+
 
 def test_with_flag_inferred_default():
-    @annotations.with_annotated_args
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("meow")
+    @tanjun.as_slash_command("ea", "meow")
     async def callback(
-        ctx: tanjun.abc.MessageContext,
-        eep: typing.Annotated[annotations.Int, annotations.Flag(aliases=("--hi", "--bye"))] = 123,
+        ctx: tanjun.abc.Context,
+        eep: typing.Annotated[annotations.Int, annotations.Flag(aliases=("--hi", "--bye")), "a"] = 123,
     ) -> None:
         ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
+    assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
     assert len(callback.parser.arguments) == 0
     assert len(callback.parser.options) == 1
     option = callback.parser.options[0]
@@ -1141,6 +1158,19 @@ def test_with_flag_inferred_default():
     assert option.is_multi is False
     assert option.min_value is None
     assert option.max_value is None
+
+    assert callback.wrapped_command.build().options == [
+        hikari.CommandOption(
+            type=hikari.OptionType.INTEGER,
+            name="eep",
+            channel_types=None,
+            description="a",
+            is_required=False,
+        )
+    ]
+    assert len(callback.wrapped_command._tracked_options) == 1
+    option = callback.wrapped_command._tracked_options["eep"]
+    assert option.default == 123
 
 
 def test_with_flag_missing_default():
@@ -1154,6 +1184,111 @@ def test_with_flag_missing_default():
 
     with pytest.raises(ValueError, match="Flag argument 'noooo' must have a default"):
         annotations.with_annotated_args(callback)
+
+
+def test_with_positional():
+    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @tanjun.as_message_command("name")
+    @tanjun.as_slash_command("boop", "description")
+    async def callback(
+        ctx: tanjun.abc.Context, beep: typing.Annotated[annotations.Str, annotations.Positional(), "eat"]
+    ) -> None:
+        ...
+
+    assert isinstance(callback.parser, tanjun.ShlexParser)
+    assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
+    assert len(callback.parser.arguments) == 1
+    assert len(callback.parser.options) == 0
+    option = callback.parser.arguments[0]
+    assert option.key == "beep"
+    assert option.converters == []
+    assert option.default is tanjun.parsing.UNDEFINED
+    assert option.is_multi is False
+    assert option.min_value is None
+    assert option.max_value is None
+
+    assert callback.wrapped_command.build().options == [
+        hikari.CommandOption(
+            type=hikari.OptionType.STRING,
+            name="beep",
+            channel_types=None,
+            description="eat",
+            is_required=True,
+        )
+    ]
+    assert len(callback.wrapped_command._tracked_options) == 1
+    option = callback.wrapped_command._tracked_options["beep"]
+    assert option.default is tanjun.commands.slash.UNDEFINED_DEFAULT
+
+
+def test_with_poisitional_explicit_default():
+    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @tanjun.as_message_command("noot")
+    @tanjun.as_slash_command("boom", "description 2")
+    async def callback(
+        ctx: tanjun.abc.Context, nom: typing.Annotated[annotations.Str, annotations.Positional(default="ok"), "hi"]
+    ) -> None:
+        ...
+
+    assert isinstance(callback.parser, tanjun.ShlexParser)
+    assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
+    assert len(callback.parser.arguments) == 1
+    assert len(callback.parser.options) == 0
+    option = callback.parser.arguments[0]
+    assert option.key == "nom"
+    assert option.converters == []
+    assert option.default == "ok"
+    assert option.is_multi is False
+    assert option.min_value is None
+    assert option.max_value is None
+
+    assert callback.wrapped_command.build().options == [
+        hikari.CommandOption(
+            type=hikari.OptionType.STRING,
+            name="nom",
+            channel_types=None,
+            description="hi",
+            is_required=False,
+        )
+    ]
+    assert len(callback.wrapped_command._tracked_options) == 1
+    option = callback.wrapped_command._tracked_options["nom"]
+    assert option.default == "ok"
+
+
+def test_with_positional_passed_default():
+    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @tanjun.as_message_command("nom")
+    @tanjun.as_slash_command("blam", "description 3")
+    async def callback(
+        ctx: tanjun.abc.Context, noop: typing.Annotated[annotations.Str, annotations.Positional(), "bye"] = "no"
+    ) -> None:
+        ...
+
+    assert isinstance(callback.parser, tanjun.ShlexParser)
+    assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
+    assert len(callback.parser.arguments) == 1
+    assert len(callback.parser.options) == 0
+    option = callback.parser.arguments[0]
+    assert option.key == "noop"
+    assert option.converters == []
+    assert option.default == "no"
+    assert option.is_multi is False
+    assert option.min_value is None
+    assert option.max_value is None
+
+    assert callback.wrapped_command.build().options == [
+        hikari.CommandOption(
+            type=hikari.OptionType.STRING,
+            name="noop",
+            channel_types=None,
+            description="bye",
+            is_required=False,
+        )
+    ]
+    assert len(callback.wrapped_command._tracked_options) == 1
+    option = callback.wrapped_command._tracked_options["noop"]
+    assert option.default == "no"
 
 
 def test_with_greedy():

--- a/tests/test_annotations_future_annotations.py
+++ b/tests/test_annotations_future_annotations.py
@@ -223,7 +223,7 @@ def test_when_follow_wrapping_and_wrapping_unsupported_command():
 
 
 def test_with_with_std_range():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -280,7 +280,7 @@ def test_with_with_std_range():
 
 
 def test_with_with_backwards_std_range():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -337,7 +337,7 @@ def test_with_with_backwards_std_range():
 
 
 def test_with_std_slice():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -394,7 +394,7 @@ def test_with_std_slice():
 
 
 def test_with_backwards_std_slice():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -572,7 +572,7 @@ def test_choices(
     choices_ = choices
     type_cls_ = type_cls
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     async def callback(
         ctx: tanjun.abc.Context,
@@ -678,7 +678,7 @@ def test_with_generic_float_choices():
         Blam = 432.123
         Ok = 43.34
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -769,7 +769,7 @@ def test_with_generic_int_choices():
         Batman = 123
         Bazman = 0
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -859,7 +859,7 @@ def test_with_generic_str_choices():
         Sis = "pls"
         Catgirl = "uwu"
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1211,7 +1211,7 @@ def test_with_flag_missing_default():
 
 
 def test_with_positional():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("name")
     @tanjun.as_slash_command("boop", "description")
     async def callback(
@@ -1246,7 +1246,7 @@ def test_with_positional():
 
 
 def test_with_poisitional_explicit_default():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("noot")
     @tanjun.as_slash_command("boom", "description 2")
     async def callback(
@@ -1281,7 +1281,7 @@ def test_with_poisitional_explicit_default():
 
 
 def test_with_positional_passed_default():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("nom")
     @tanjun.as_slash_command("blam", "description 3")
     async def callback(
@@ -1316,7 +1316,7 @@ def test_with_positional_passed_default():
 
 
 def test_with_greedy():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
@@ -1337,7 +1337,7 @@ def test_with_greedy():
 
 
 def test_with_generic_greedy():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
@@ -1375,7 +1375,7 @@ def test_with_max(
     type__ = type_
     value_ = value
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1459,7 +1459,7 @@ def test_with_generic_max(
     global value_
     value_ = value
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1638,7 +1638,7 @@ def test_with_min(
     type__ = type_
     value_ = value
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1722,7 +1722,7 @@ def test_with_generic_min(
     global value_
     value_ = value
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1884,7 +1884,7 @@ def test_with_min_when_int_for_float():
 
 
 def test_with_overridden_name():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -1959,7 +1959,7 @@ def test_with_overridden_name():
 
 
 def test_with_individually_overridden_name():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -2036,7 +2036,7 @@ def test_with_individually_overridden_name():
 
 
 def test_with_overridden_slash_name():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -2111,7 +2111,7 @@ def test_with_overridden_slash_name():
 
 
 def test_with_overridden_message_name():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -2158,7 +2158,7 @@ def test_with_overridden_message_name():
 
 
 def test_with_ranged():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -2234,7 +2234,7 @@ def test_with_generic_ranged(
     min_value_ = min_value
     max_value_ = max_value
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
@@ -2312,7 +2312,7 @@ def test_with_snowflake_or():
     global mock_callback
     mock_callback = mock.Mock()
 
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2388,7 +2388,7 @@ def test_with_snowflake_or():
 
 
 def test_with_generic_snowflake_or_for_channel():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2464,7 +2464,7 @@ def test_with_generic_snowflake_or_for_channel():
 
 
 def test_with_generic_snowflake_or_for_member():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2540,7 +2540,7 @@ def test_with_generic_snowflake_or_for_member():
 
 
 def test_with_generic_snowflake_or_for_mentionable():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2616,7 +2616,7 @@ def test_with_generic_snowflake_or_for_mentionable():
 
 
 def test_with_generic_snowflake_or_for_role():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2692,7 +2692,7 @@ def test_with_generic_snowflake_or_for_role():
 
 
 def test_with_generic_snowflake_or_for_user():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
@@ -2768,7 +2768,7 @@ def test_with_generic_snowflake_or_for_user():
 
 
 def test_with_generic_snowflake_or():
-    @tanjun.annotations.with_annotated_args(follow_wrapped=True)
+    @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
     @tanjun.as_slash_command("yeet", "description")
     async def callback(


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
Closes: #394

