### PR TITLE
Make SlashCommand.as_sub_command's typing more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make [tanjun.commands.slash.SlashCommand.as_sub_command][]'s typing more
+  flexible to allow decorating other command objects.
 
 ## [2.7.0a1] - 2022-09-24
 ### Added

--- a/tanjun/commands/slash.py
+++ b/tanjun/commands/slash.py
@@ -1147,7 +1147,7 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
         default_to_ephemeral: typing.Optional[bool] = None,
         sort_options: bool = True,
         validate_arg_keys: bool = True,
-    ) -> collections.Callable[[_CommandCallbackSigT], SlashCommand[_CommandCallbackSigT]]:
+    ) -> _ResultProto:
         r"""Build a [tanjun.SlashCommand][] in this command group by decorating a function.
 
         !!! note
@@ -1199,16 +1199,20 @@ class SlashCommandGroup(BaseSlashCommand, tanjun.SlashCommandGroup):
             * If the command name has uppercase characters.
             * If the description is over 100 characters long.
         """
-        return lambda callback: self.with_command(
-            as_slash_command(
-                name,
-                description,
-                always_defer=always_defer,
-                default_to_ephemeral=default_to_ephemeral,
-                sort_options=sort_options,
-                validate_arg_keys=validate_arg_keys,
-            )(callback)
-        )
+
+        def decorator(callback: _CallbackishT[_CommandCallbackSigT], /) -> SlashCommand[_CommandCallbackSigT]:
+            return self.with_command(
+                as_slash_command(
+                    name,
+                    description,
+                    always_defer=always_defer,
+                    default_to_ephemeral=default_to_ephemeral,
+                    sort_options=sort_options,
+                    validate_arg_keys=validate_arg_keys,
+                )(callback)
+            )
+
+        return decorator
 
     def make_sub_group(
         self,


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
