### PR TITLE
Allow `delete_after` for ephemeral responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- No longer ignore `delete_after` for ephemeral responses.
 
 ## [2.8.0a1] - 2022-10-16
 ### Added

--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -460,10 +460,6 @@ class Context(alluka.Context):
     ) -> hikari.Message:
         """Edit the initial response for this context.
 
-        !!! note
-            Since (as of writing) ephemeral responses cannot be deleted by the bot,
-            `delete_after` is ignored for ephemeral slash command responses.
-
         Parameters
         ----------
         content
@@ -587,10 +583,6 @@ class Context(alluka.Context):
         ] = hikari.UNDEFINED,
     ) -> hikari.Message:
         """Edit the last response for this context.
-
-        !!! note
-            Since (as of writing) ephemeral responses cannot be deleted by the bot,
-            `delete_after` is ignored for ephemeral slash command responses.
 
         Parameters
         ----------
@@ -785,10 +777,6 @@ class Context(alluka.Context):
         ] = hikari.UNDEFINED,
     ) -> typing.Optional[hikari.Message]:
         """Respond to this context.
-
-        !!! note
-            Since (as of writing) ephemeral responses cannot be deleted by the bot,
-            `delete_after` is ignored for ephemeral slash command responses.
 
         Parameters
         ----------
@@ -1428,10 +1416,6 @@ class AppCommandContext(Context, abc.ABC):
             Calling this on a context which hasn't had an initial response yet
             will lead to a [hikari.errors.NotFoundError][] being raised.
 
-        !!! note
-            Since (as of writing) ephemeral responses cannot be deleted by the bot,
-            `delete_after` is ignored for ephemeral slash command responses.
-
         Parameters
         ----------
         content
@@ -1553,10 +1537,6 @@ class AppCommandContext(Context, abc.ABC):
             will result in this raising a [hikari.errors.NotFoundError][].
             This includes if the REST interaction server has already responded
             to the request and deferrals.
-
-        !!! note
-            Since (as of writing) ephemeral responses cannot be deleted by the bot,
-            `delete_after` is ignored for ephemeral slash command responses.
 
         Parameters
         ----------

--- a/tanjun/context/slash.py
+++ b/tanjun/context/slash.py
@@ -514,7 +514,7 @@ class AppCommandContext(base.BaseContext, tanjun.AppCommandContext):
         # unexpected behaviour around deferrals) should be accounted for.
         self._has_responded = True
 
-        if delete_after is not None and not message.flags & hikari.MessageFlag.EPHEMERAL:
+        if delete_after is not None:
             self._register_task(asyncio.create_task(self._delete_followup_after(delete_after, message)))
 
         return message
@@ -642,7 +642,7 @@ class AppCommandContext(base.BaseContext, tanjun.AppCommandContext):
             self._response_future.set_result(result)
 
         self._has_responded = True
-        if delete_after is not None and not flags & hikari.MessageFlag.EPHEMERAL:
+        if delete_after is not None:
             self._register_task(asyncio.create_task(self._delete_initial_response_after(delete_after)))
 
     async def create_initial_response(
@@ -747,7 +747,7 @@ class AppCommandContext(base.BaseContext, tanjun.AppCommandContext):
         # This will be False if the initial response was deferred with this finishing the referral.
         self._has_responded = True
 
-        if delete_after is not None and not message.flags & hikari.MessageFlag.EPHEMERAL:
+        if delete_after is not None:
             self._register_task(asyncio.create_task(self._delete_initial_response_after(delete_after)))
 
         return message
@@ -789,7 +789,7 @@ class AppCommandContext(base.BaseContext, tanjun.AppCommandContext):
                 user_mentions=user_mentions,
                 role_mentions=role_mentions,
             )
-            if delete_after is not None and not message.flags & hikari.MessageFlag.EPHEMERAL:
+            if delete_after is not None:
                 self._register_task(asyncio.create_task(self._delete_followup_after(delete_after, message)))
 
             return message

--- a/tests/context/test_slash.py
+++ b/tests/context/test_slash.py
@@ -902,30 +902,6 @@ class TestAppCommandContext:
         create_task.assert_called_once_with(mock_delete_initial_response_after.return_value)
         mock_register_task.assert_called_once_with(create_task.return_value)
 
-    @pytest.mark.parametrize("delete_after", [datetime.timedelta(seconds=545), 545, 545.0])
-    @pytest.mark.asyncio()
-    async def test_edit_initial_response_ignores_delete_after_when_is_ephemeral(
-        self, mock_client: mock.Mock, delete_after: typing.Union[datetime.timedelta, int, float]
-    ):
-        mock_delete_initial_response_after = mock.Mock()
-        mock_interaction = mock.AsyncMock(created_at=datetime.datetime.now(tz=datetime.timezone.utc))
-        mock_interaction.edit_initial_response.return_value.flags = hikari.MessageFlag.EPHEMERAL
-        mock_register_task = mock.Mock()
-        context = stub_class(
-            tanjun.context.slash.AppCommandContext,
-            type=mock.Mock(),
-            mark_not_found=mock.AsyncMock(),
-            _delete_initial_response_after=mock_delete_initial_response_after,
-            args=(mock_client, mock_interaction, mock_register_task),
-        )
-
-        with mock.patch.object(asyncio, "create_task") as create_task:
-            await context.edit_initial_response("bye", delete_after=delete_after)
-
-        mock_delete_initial_response_after.assert_not_called()
-        create_task.assert_not_called()
-        mock_register_task.assert_not_called()
-
     @pytest.mark.parametrize("delete_after", [datetime.timedelta(seconds=901), 901, 901.0])
     @pytest.mark.asyncio()
     async def test_edit_initial_response_when_delete_after_will_have_expired(


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
