### PR TITLE
Fix MessageContext.triggering_name's handling of group spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [with_channel_slash_option][tanjun.commands.with_channel_slash_option] and
   [SlashCommand.add_channel_option][tanjun.commands.SlashCommand.add_channel_option].
 - The spacing in `triggering_name` is now properly normalised for message commands in groups to ensure
-  only ever 1 space. This also fixes cases where names were being smushed together without any spaces.
+  only 1 space. This also fixes cases where names were being smushed together without any spaces.
 - The hot reloader trying to declare commands multiple times.
 
 ## [2.9.0a1] - 2022-11-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [TheseChannels][tanjun.annotations.TheseChannels], and to the `types` field of
   [with_channel_slash_option][tanjun.commands.with_channel_slash_option] and
   [SlashCommand.add_channel_option][tanjun.commands.SlashCommand.add_channel_option].
+- The spacing in `triggering_name` is now properly normalised for message commands in groups to ensure
+  only ever 1 space. This also fixes cases where names were being smushed together without any spaces.
 
 ## [2.9.0a1] - 2022-11-08
 ### Added

--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -912,11 +912,6 @@ class MessageContext(Context, abc.ABC):
     def triggering_prefix(self) -> str:
         """Prefix that triggered the context."""
 
-    @property
-    @abc.abstractmethod
-    def triggering_name(self) -> str:
-        """Command name that triggered the context."""
-
     @abc.abstractmethod
     def set_command(self, command: typing.Optional[MessageCommand[typing.Any]], /) -> Self:
         raise NotImplementedError

--- a/tanjun/commands/message.py
+++ b/tanjun/commands/message.py
@@ -628,10 +628,8 @@ class MessageCommandGroup(MessageCommand[_CommandCallbackSigT], tanjun.MessageCo
         for name, command in self.find_command(ctx.content):
             if await command.check_context(ctx):
                 content = ctx.content[len(name) :]
-                lstripped_content = content.lstrip()
-                space_len = len(content) - len(lstripped_content)
-                ctx.set_triggering_name(ctx.triggering_name + (" " * space_len) + name)
-                ctx.set_content(lstripped_content)
+                ctx.set_triggering_name(ctx.triggering_name + " " + name)
+                ctx.set_content(content.lstrip())
                 await command.execute(ctx, hooks=hooks)
                 return
 


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
