### PR TITLE
Publicly export parse_annotated_args to allow building around it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Slash command specific [tanjun.annotations.InteractionChannel][] and
   [tanjun.annotations.InteractionMember][] types for annotation parsing.
+- Exposed non-decorator version of [with_annotated_args][tanjun.annotations.with_annotated_args][]
+  at [tanjun.annotations.parse_annotated_args][].
+  This comes with the added functionality of letting you directly pass slash command option
+  descriptions to the callback via the `descriptions` argument (instead of putting strings in
+  annotations).
 
 ### Changed
 - [tanjun.annotations.with_annotated_args][] will now raise if a slash command-specific type is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Slash command specific [tanjun.annotations.InteractionChannel][] and
   [tanjun.annotations.InteractionMember][] types for annotation parsing.
-- Exposed non-decorator version of [with_annotated_args][tanjun.annotations.with_annotated_args][]
+- Exposed non-decorator version of [with_annotated_args][tanjun.annotations.with_annotated_args]
   at [tanjun.annotations.parse_annotated_args][].
   This comes with the added functionality of letting you directly pass slash command option
   descriptions to the callback via the `descriptions` argument (instead of putting strings in

--- a/tanjun/_internal/__init__.py
+++ b/tanjun/_internal/__init__.py
@@ -72,10 +72,10 @@ _CoroT = collections.Coroutine[typing.Any, typing.Any, _T]
 _LOGGER = logging.getLogger("hikari.tanjun")
 
 if sys.version_info >= (3, 10):
-    _UnionTypes = frozenset((typing.Union, types.UnionType))
+    UnionTypes = frozenset((typing.Union, types.UnionType))
 
 else:
-    _UnionTypes = frozenset((typing.Union,))
+    UnionTypes = frozenset((typing.Union,))
 
 
 class _NoDefaultEnum(enum.Enum):
@@ -200,7 +200,7 @@ _POSITIONAL_TYPES = {
 
 def _snoop_types(type_: typing.Any, /) -> collections.Iterator[typing.Any]:
     origin = typing.get_origin(type_)
-    if origin in _UnionTypes:
+    if origin in UnionTypes:
         yield from itertools.chain.from_iterable(map(_snoop_types, typing.get_args(type_)))
 
     elif origin is typing.Annotated:

--- a/tanjun/annotations.py
+++ b/tanjun/annotations.py
@@ -75,8 +75,6 @@ import abc
 import enum
 import itertools
 import operator
-import sys
-import types
 import typing
 import warnings
 from collections import abc as collections
@@ -92,12 +90,6 @@ from .commands import slash
 
 if typing.TYPE_CHECKING:
     from typing_extensions import Self
-
-if sys.version_info >= (3, 10):
-    _UnionTypes = frozenset((typing.Union, types.UnionType))
-
-else:
-    _UnionTypes = frozenset((typing.Union,))
 
 _T = typing.TypeVar("_T")
 _ChannelTypeIsh = typing.Union[type[hikari.PartialChannel], int]
@@ -1311,7 +1303,7 @@ def _snoop_annotation_args(type_: typing.Any) -> collections.Iterator[typing.Any
         yield from _snoop_annotation_args(args[0])
         yield from args[1:]
 
-    elif origin in _UnionTypes:
+    elif origin in _internal.UnionTypes:
         yield from itertools.chain.from_iterable(map(_snoop_annotation_args, typing.get_args(type_)))
 
 

--- a/tanjun/annotations.py
+++ b/tanjun/annotations.py
@@ -1316,7 +1316,7 @@ def parse_annotated_args(
 ) -> None:
     """Set a command's arguments based on its signature.
 
-    For more information on how this works see [][tanjun.annotations.with_annotated_args]
+    For more information on how this works see [tanjun.annotations.with_annotated_args][]
     which acts as the decorator equivalent of this. The only difference is
     function allows passing a mapping of argument descriptions.
 

--- a/tanjun/annotations.py
+++ b/tanjun/annotations.py
@@ -1335,7 +1335,8 @@ def parse_annotated_args(
     descriptions
         Mapping of descriptions to use for this command's slash command options.
 
-        If an option isn't included here then the
+        If an option isn't included here then this will default back to getting
+        the description from its annotation.
     follow_wrapped
         Whether this should also set the arguments on any other command objects
         this wraps in a decorator call chain.


### PR DESCRIPTION
Add support for explicitly passing slash option descriptions to parse_annotated_args through a mapping

### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
