### PR TITLE
Make a message command index error more generic

### DIFF
--- a/tanjun/_internal/__init__.py
+++ b/tanjun/_internal/__init__.py
@@ -511,7 +511,7 @@ class MessageCommandIndex:
 
         if self.is_strict:
             if any(" " in name for name in command.names):
-                raise ValueError("Command name cannot contain spaces for this configuration.")
+                raise ValueError("Command name cannot contain spaces in a strict collection")
 
             names = list(filter(None, command.names))
             insensitive_names = [name.casefold() for name in command.names]

--- a/tanjun/_internal/__init__.py
+++ b/tanjun/_internal/__init__.py
@@ -511,7 +511,7 @@ class MessageCommandIndex:
 
         if self.is_strict:
             if any(" " in name for name in command.names):
-                raise ValueError("Command name cannot contain spaces for this component implementation")
+                raise ValueError("Command name cannot contain spaces for this configuration.")
 
             names = list(filter(None, command.names))
             insensitive_names = [name.casefold() for name in command.names]

--- a/tests/commands/test_message.py
+++ b/tests/commands/test_message.py
@@ -468,7 +468,7 @@ class TestMessageCommandGroup:
     def test_add_command_when_strict_and_space_in_any_name(self):
         command_group = tanjun.MessageCommandGroup[typing.Any](mock.Mock(), "yee", "nsoosos", strict=True)
 
-        with pytest.raises(ValueError, match="Command name cannot contain spaces for this component implementation"):
+        with pytest.raises(ValueError, match="Command name cannot contain spaces in a strict collection"):
             command_group.add_command(mock.Mock(names={"a space", "b"}))
 
     def test_add_command_when_strict_and_conflicts_found(self):

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -957,7 +957,7 @@ class TestComponent:
         component = tanjun.Component(strict=True)
         mock_command = mock.Mock(names=("a b",))
 
-        with pytest.raises(ValueError, match="Command name cannot contain spaces for this component implementation"):
+        with pytest.raises(ValueError, match="Command name cannot contain spaces in a strict collection"):
             component.add_message_command(mock_command)
 
         mock_command.bind_client.assert_not_called()


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
