### PR TITLE
Some small mypy compatability improvements for tanjun.annotations

### DIFF
--- a/tanjun/annotations.py
+++ b/tanjun/annotations.py
@@ -72,6 +72,7 @@ __all__: list[str] = [
 ]
 
 import abc
+import datetime
 import enum
 import itertools
 import operator
@@ -324,16 +325,16 @@ class Converted(_ConfigIdentifier, metaclass=_ConvertedMeta):
         config.converters = self._converters
 
 
-Color = Converted[conversion.to_color]
+Color = typing.Annotated[hikari.Color, Converted(conversion.to_color)]
 """An argument which takes a color."""
 
 Colour = Color
 """An argument which takes a colour."""
 
-Datetime = Converted[conversion.to_datetime]
+Datetime = typing.Annotated[datetime.datetime, Converted(conversion.to_datetime)]
 """An argument which takes a datetime."""
 
-Snowflake = Converted[conversion.parse_snowflake]
+Snowflake = typing.Annotated[hikari.Snowflake, Converted(conversion.parse_snowflake)]
 """An argument which takes a snowflake."""
 
 


### PR DESCRIPTION
### Summary
This ensures mypy won't complain about the default Converted types in tanjun.annotations

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
