### PR TITLE
Ensure set_human_only doesn't dupe the check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [tanjun.clients.Client.set_human_only][] no longer registers the internal check multiple
+  times when called with [True][] multiple times.
+
 ### [2.11.1] - 2023-01-07
 ### Added
 - Support for specifying Guild Forum channels for the constraints of a channel command option.

--- a/tanjun/clients.py
+++ b/tanjun/clients.py
@@ -1745,10 +1745,10 @@ class Client(tanjun.Client):
             Passing [True][] here will prevent message commands from being executed
             based on webhook and bot messages.
         """
-        if value:
+        if value and _check_human not in self._checks:
             self.add_check(_check_human)
 
-        else:
+        elif not value:
             try:
                 self.remove_check(_check_human)
             except ValueError:

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -806,6 +806,34 @@ class TestClient:
     async def test_declare_global_commands(self):
         ...
 
+    def test_set_human_only(self):
+        client = tanjun.Client(mock.Mock()).set_human_only(False)
+
+        result = client.set_human_only(True)
+
+        assert result is client
+        assert client.is_human_only is True
+        assert tanjun.clients._check_human in client.checks
+
+    def test_set_human_only_when_false(self):
+        client = tanjun.Client(mock.Mock()).set_human_only(True).set_human_only(True)
+
+        result = client.set_human_only(False)
+
+        assert result is client
+        assert client.is_human_only is False
+        assert tanjun.clients._check_human not in client.checks
+
+    def test_set_human_only_with_dupped_true_calls(self):
+        client = tanjun.Client(mock.Mock()).set_human_only(False)
+
+        client.set_human_only(True)
+        client.set_human_only(True)
+        client.set_human_only(True)
+
+        assert client.is_human_only is True
+        assert list(client.checks).count(tanjun.clients._check_human) == 1
+
     def test_add_check(self):
         mock_check = mock.Mock()
         client = tanjun.Client(mock.Mock())


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
