### PR TITLE
Fix handling of special types being passed as `content` for REST cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Context.create_initial_response` (and by extension `Context.respond` for the initial
+  response specifically) will no-longer try to pass the attachment, component or embed as
+  the actual message content when passed for the `content` argument for REST-based
+  interaction commands.
 
 ## [2.11.3] - 2023-02-01
 ### Added

--- a/tanjun/commands/menu.py
+++ b/tanjun/commands/menu.py
@@ -573,9 +573,7 @@ class MenuCommand(base.PartialCommand[tanjun.MenuContext], tanjun.MenuCommand[_A
     def build(self, *, component: typing.Optional[tanjun.Component] = None) -> hikari.api.ContextMenuCommandBuilder:
         # <<inherited docstring from tanjun.abc.MenuCommand>>.
         builder = hikari.impl.ContextMenuCommandBuilder(
-            type=self._type,
-            name=self._names.default_value,
-            name_localizations=self._names.localised_values,  # pyright: ignore [ reportGeneralTypeIssues ]
+            type=self._type, name=self._names.default_value, name_localizations=self._names.localised_values
         )
 
         component = component or self._component

--- a/tanjun/commands/slash.py
+++ b/tanjun/commands/slash.py
@@ -836,9 +836,9 @@ class _SlashCommandBuilder(hikari.impl.SlashCommandBuilder):
         super().__init__(
             name=name,
             description=description,
-            description_localizations=description_localizations,  # pyright: ignore [ reportGeneralTypeIssues ]
-            id=id_,  # pyright: ignore [ reportGeneralTypeIssues ]
-            name_localizations=name_localizations,  # pyright: ignore [ reportGeneralTypeIssues ]
+            description_localizations=description_localizations,
+            id=id_,
+            name_localizations=name_localizations,
         )
         self._has_been_sorted = True
         self._options_dict: dict[str, hikari.CommandOption] = {}

--- a/tanjun/context/slash.py
+++ b/tanjun/context/slash.py
@@ -54,6 +54,7 @@ if typing.TYPE_CHECKING:
         hikari.api.InteractionMessageBuilder, hikari.api.InteractionDeferredBuilder, hikari.api.InteractionModalBuilder
     ]
     _T = typing.TypeVar("_T")
+    _OtherT = typing.TypeVar("_OtherT")
 
 
 _INTERACTION_LIFETIME: typing.Final[datetime.timedelta] = datetime.timedelta(minutes=15)
@@ -623,9 +624,9 @@ class AppCommandContext(base.BaseContext, tanjun.AppCommandContext):
             )
 
         else:
-            attachments = _to_list(attachment, attachments, content, _ATTACHMENT_TYPES, "attachment")
-            components = _to_list(component, components, content, hikari.api.ComponentBuilder, "component")
-            embeds = _to_list(embed, embeds, content, hikari.Embed, "embed")
+            attachments, content = _to_list(attachment, attachments, content, _ATTACHMENT_TYPES, "attachment")
+            components, content = _to_list(component, components, content, hikari.api.ComponentBuilder, "component")
+            embeds, content = _to_list(embed, embeds, content, hikari.Embed, "embed")
 
             content = str(content) if content is not hikari.UNDEFINED else hikari.UNDEFINED
             # Pyright doesn't properly support attrs and doesn't account for _ being removed from field
@@ -840,7 +841,7 @@ class AppCommandContext(base.BaseContext, tanjun.AppCommandContext):
                 raise RuntimeError("Initial response has already been created")
 
             if self._response_future:
-                components = _to_list(component, components, None, hikari.api.ComponentBuilder, "component")
+                components, _ = _to_list(component, components, None, hikari.api.ComponentBuilder, "component")
 
                 response = hikari.impl.InteractionModalBuilder(title, custom_id, components)
                 self._response_future.set_result(response)
@@ -974,26 +975,26 @@ _ATTACHMENT_TYPES: tuple[type[typing.Any], ...] = (hikari.files.Resource, *hikar
 
 
 def _to_list(
-    singular: hikari.UndefinedOr[_T],
-    plural: hikari.UndefinedOr[collections.Sequence[_T]],
-    other: typing.Any,
-    type_: typing.Union[type[typing.Any], tuple[type[typing.Any], ...]],
+    singular: hikari.UndefinedNoneOr[_T],
+    plural: hikari.UndefinedNoneOr[collections.Sequence[_T]],
+    other: hikari.UndefinedNoneOr[_OtherT],
+    type_: typing.Union[type[_T], tuple[type[_T], ...]],
     name: str,
     /,
-) -> list[_T]:
+) -> tuple[list[_T], hikari.UndefinedNoneOr[_OtherT]]:
     if singular is not hikari.UNDEFINED and plural is not hikari.UNDEFINED:
         raise ValueError(f"Only one of {name} or {name}s may be passed")
 
     if singular:
-        return [singular]
+        return [singular], other
 
     if plural:
-        return list(plural)
+        return list(plural), other
 
     if other and isinstance(other, type_):
-        return [other]
+        return [other], None
 
-    return []
+    return [], other
 
 
 class SlashContext(AppCommandContext, tanjun.SlashContext):

--- a/tanjun/context/slash.py
+++ b/tanjun/context/slash.py
@@ -992,7 +992,7 @@ def _to_list(
         return list(plural), other
 
     if other and isinstance(other, type_):
-        return [other], None
+        return [other], undefined.UNDEFINED
 
     return hikari.UNDEFINED, other
 

--- a/tanjun/context/slash.py
+++ b/tanjun/context/slash.py
@@ -992,7 +992,7 @@ def _to_list(
         return list(plural), other
 
     if other and isinstance(other, type_):
-        return [other], undefined.UNDEFINED
+        return [other], hikari.UNDEFINED
 
     return hikari.UNDEFINED, other
 

--- a/tanjun/context/slash.py
+++ b/tanjun/context/slash.py
@@ -981,7 +981,7 @@ def _to_list(
     type_: typing.Union[type[_T], tuple[type[_T], ...]],
     name: str,
     /,
-) -> tuple[list[_T], hikari.UndefinedNoneOr[_OtherT]]:
+) -> tuple[list[_T], hikari.UndefinedOr[_OtherT]]:
     if singular is not hikari.UNDEFINED and plural is not hikari.UNDEFINED:
         raise ValueError(f"Only one of {name} or {name}s may be passed")
 

--- a/tanjun/context/slash.py
+++ b/tanjun/context/slash.py
@@ -977,7 +977,7 @@ _ATTACHMENT_TYPES: tuple[type[typing.Any], ...] = (hikari.files.Resource, *hikar
 def _to_list(
     singular: hikari.UndefinedOr[_T],
     plural: hikari.UndefinedOr[collections.Sequence[_T]],
-    other: hikari.UndefinedOr[_OtherT],
+    other: _OtherT,
     type_: typing.Union[type[_T], tuple[type[_T], ...]],
     name: str,
     /,

--- a/tanjun/context/slash.py
+++ b/tanjun/context/slash.py
@@ -843,7 +843,7 @@ class AppCommandContext(base.BaseContext, tanjun.AppCommandContext):
             if self._response_future:
                 components, _ = _to_list(component, components, None, hikari.api.ComponentBuilder, "component")
 
-                response = hikari.impl.InteractionModalBuilder(title, custom_id, components)
+                response = hikari.impl.InteractionModalBuilder(title, custom_id, components or [])
                 self._response_future.set_result(response)
 
             else:

--- a/tanjun/context/slash.py
+++ b/tanjun/context/slash.py
@@ -975,9 +975,9 @@ _ATTACHMENT_TYPES: tuple[type[typing.Any], ...] = (hikari.files.Resource, *hikar
 
 
 def _to_list(
-    singular: hikari.UndefinedNoneOr[_T],
-    plural: hikari.UndefinedNoneOr[collections.Sequence[_T]],
-    other: hikari.UndefinedNoneOr[_OtherT],
+    singular: hikari.UndefinedOr[_T],
+    plural: hikari.UndefinedOr[collections.Sequence[_T]],
+    other: hikari.UndefinedOr[_OtherT],
     type_: typing.Union[type[_T], tuple[type[_T], ...]],
     name: str,
     /,

--- a/tanjun/context/slash.py
+++ b/tanjun/context/slash.py
@@ -985,16 +985,16 @@ def _to_list(
     if singular is not hikari.UNDEFINED and plural is not hikari.UNDEFINED:
         raise ValueError(f"Only one of {name} or {name}s may be passed")
 
-    if singular:
+    if singular is not hikari.UNDEFINED:
         return [singular], other
 
-    if plural:
+    if plural is not hikari.UNDEFINED:
         return list(plural), other
 
     if other and isinstance(other, type_):
         return [other], None
 
-    return [], other
+    return hikari.UNDEFINED, other
 
 
 class SlashContext(AppCommandContext, tanjun.SlashContext):

--- a/tanjun/context/slash.py
+++ b/tanjun/context/slash.py
@@ -634,14 +634,14 @@ class AppCommandContext(base.BaseContext, tanjun.AppCommandContext):
             result = hikari.impl.InteractionMessageBuilder(
                 hikari.ResponseType.MESSAGE_CREATE,
                 content,
-                attachments=attachments,  # pyright: ignore [ reportGeneralTypeIssues ]
-                components=components,  # pyright: ignore [ reportGeneralTypeIssues ]
-                embeds=embeds,  # pyright: ignore [ reportGeneralTypeIssues ]
-                flags=flags,  # pyright: ignore [ reportGeneralTypeIssues ]
-                is_tts=tts,  # pyright: ignore [ reportGeneralTypeIssues ]
-                mentions_everyone=mentions_everyone,  # pyright: ignore [ reportGeneralTypeIssues ]
-                user_mentions=user_mentions,  # pyright: ignore [ reportGeneralTypeIssues ]
-                role_mentions=role_mentions,  # pyright: ignore [ reportGeneralTypeIssues ]
+                attachments=attachments,
+                components=components,
+                embeds=embeds,
+                flags=flags,
+                is_tts=tts,
+                mentions_everyone=mentions_everyone,
+                user_mentions=user_mentions,  # pyright: ignore [ reportGeneralTypeIssues ]  # TODO: hikari fix
+                role_mentions=role_mentions,  # pyright: ignore [ reportGeneralTypeIssues ]  # TODO: hikari fix
             )
 
             self._response_future.set_result(result)
@@ -981,7 +981,7 @@ def _to_list(
     type_: typing.Union[type[_T], tuple[type[_T], ...]],
     name: str,
     /,
-) -> tuple[list[_T], hikari.UndefinedOr[_OtherT]]:
+) -> tuple[hikari.UndefinedOr[list[_T]], hikari.UndefinedOr[_OtherT]]:
     if singular is not hikari.UNDEFINED and plural is not hikari.UNDEFINED:
         raise ValueError(f"Only one of {name} or {name}s may be passed")
 


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
