### PR TITLE
Fix runtime spelling of AnyCheckSig

### DIFF
--- a/tanjun/abc.py
+++ b/tanjun/abc.py
@@ -262,7 +262,7 @@ else:
 
     AutocompleteSig = types.GenericAlias(collections.Callable[..., typing.Any], (_AutocompleteValueT,))
     CheckSig = types.GenericAlias(collections.Callable[..., typing.Any], (_ContextT_contra,))
-    AnyCheckSig = CheckSig
+    AnyCheckSig = CheckSig["Context"]
     MenuCallbackSig = types.GenericAlias(collections.Callable[..., typing.Any], (_MenuValueT,))
     MessageCallbackSig = collections.Callable[..., typing.Any]
     SlashCallbackSig = collections.Callable[..., typing.Any]


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
