### PR TITLE
Deprecate using annotations classes as generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Deprecated
+- Using the following classes as generic types (i.e. `Class[...]`):
+  * [yuyo.annotations.Converted][]
+  * [yuyo.annotations.Default][]
+  * [yuyo.annotations.Positional][]
+  * [yuyo.annotations.Greedy][]
+  * [yuyo.annotations.Length][]
+  * [yuyo.annotations.Max][]
+  * [yuyo.annotations.Min][]
+  * [yuyo.annotations.Ranged][]
+  * [yuyo.annotations.SnowflakeOr][]
+
 ## [2.13.0] - 2023-04-10
 ### Added
 - Support for sending stickers to just [MessageContext.respond][tanjun.abc.MessageContext.respond].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using the following classes as generic types (i.e. `Class[...]`):
   * [yuyo.annotations.Converted][]
   * [yuyo.annotations.Default][]
-  * [yuyo.annotations.Positional][]
   * [yuyo.annotations.Greedy][]
   * [yuyo.annotations.Length][]
   * [yuyo.annotations.Max][]
   * [yuyo.annotations.Min][]
+  * [yuyo.annotations.Positional][]
   * [yuyo.annotations.Ranged][]
   * [yuyo.annotations.SnowflakeOr][]
 

--- a/dev-requirements/type-checking.in
+++ b/dev-requirements/type-checking.in
@@ -2,4 +2,3 @@
 -r ../piped/python/base-requirements/nox.in
 -r ../piped/python/base-requirements/type-checking.in
 -r ./constraints.in
-pyright==1.1.294  # Pinned until bug fix

--- a/dev-requirements/type-checking.txt
+++ b/dev-requirements/type-checking.txt
@@ -551,9 +551,9 @@ pydantic==1.10.7 ; python_full_version >= "3.9.0" and python_version < "3.12" \
     --hash=sha256:e79e999e539872e903767c417c897e729e015872040e56b96e67968c3b918b2d \
     --hash=sha256:ecbbc51391248116c0a055899e6c3e7ffbb11fb5e2a4cd6f2d0b93272118a209 \
     --hash=sha256:f4a2b50e2b03d5776e7f21af73e2070e1b5c0d0df255a827e7c632962f8315af
-pyright==1.1.294 ; python_full_version >= "3.9.0" and python_version < "3.12" \
-    --hash=sha256:5b27e28a1cfc60cea707fd3b644769fa6dd0b194481cdcc2399cf2a51cc5a846 \
-    --hash=sha256:fea5fed3d6a3f02259e622c901e86a7b8bcf237d35e1cdfe01d0e0723768dcb6
+pyright==1.1.303 ; python_full_version >= "3.9.0" and python_version < "3.12" \
+    --hash=sha256:7daa516424555681e8974b21a95c108c5def791bf5381522b1410026d4da62c1 \
+    --hash=sha256:8fe3d122d7e965e2df2cef64e1ceb98cff8200f458e7892d92a4c21ee85689c7
 pytest-asyncio==0.21.0 ; python_full_version >= "3.9.0" and python_version < "3.12" \
     --hash=sha256:2b38a496aef56f56b0e87557ec313e11e1ab9276fc3863f6a7be0f1d0e415e1b \
     --hash=sha256:f2b3366b7cd501a4056858bd39349d5af19742aed2d81660b7998b6341c7eb9c

--- a/dev-requirements/type-checking.txt
+++ b/dev-requirements/type-checking.txt
@@ -250,9 +250,9 @@ exceptiongroup==1.1.1 ; python_full_version >= "3.9.0" and python_version < "3.1
 execnet==1.9.0 ; python_full_version >= "3.9.0" and python_version < "3.12" \
     --hash=sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
     --hash=sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142
-filelock==3.11.0 ; python_full_version >= "3.9.0" and python_version < "3.12" \
-    --hash=sha256:3618c0da67adcc0506b015fd11ef7faf1b493f0b40d87728e19986b536890c37 \
-    --hash=sha256:f08a52314748335c6460fc8fe40cd5638b85001225db78c2aa01c8c0db83b318
+filelock==3.12.0 ; python_full_version >= "3.9.0" and python_version < "3.12" \
+    --hash=sha256:ad98852315c2ab702aeb628412cbf7e95b7ce8c3bf9565670b4eaecf1db370a9 \
+    --hash=sha256:fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718
 freezegun==1.2.2 ; python_full_version >= "3.9.0" and python_version < "3.12" \
     --hash=sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446 \
     --hash=sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -237,12 +237,6 @@ description must be included for options when annotating for a slash command,
 which is done by passing a string value to [typing.Annotated][] (as shown
 above).
 
-The special generic types offered in [tanjun.annotations][] (e.g
-[Ranged][tanjun.annotations.Ranged] and [Converted][tanjun.annotations.Converted])
-return a [typing.Annotated][] instance from their generic calls and can also be
-passed as arguments to Annotated like `Annotated[Int, Ranged(13, 130)]`, and
-`Annotated[Str, Converted(get_video)]`.
-
 This example doesn't demonstrate every feature of this, and More information on
 how arguments are configured through annotations can be found in
 [tanjun.annotations][].

--- a/tanjun/annotations.py
+++ b/tanjun/annotations.py
@@ -220,6 +220,7 @@ class _IntEnumConverter(_ConfigIdentifier):
 
 
 class _ChoicesMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass Choices(...) too Annotated")
     def __getitem__(cls, enum_: type[_EnumT], /) -> type[_EnumT]:
         if issubclass(enum_, float):
             type_ = float
@@ -305,6 +306,7 @@ class Choices(_ConfigIdentifier, metaclass=_ChoicesMeta):
 
 
 class _ConvertedMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass Converted(...) too Annotated")
     def __getitem__(cls, converters: typing.Union[_ConverterSig[_T], tuple[_ConverterSig[_T]]], /) -> type[_T]:
         if not isinstance(converters, tuple):
             converters = (converters,)
@@ -323,12 +325,9 @@ class Converted(_ConfigIdentifier, metaclass=_ConvertedMeta):
     async def command(
         ctx: tanjun.abc.SlashContext,
         argument: Annotated[OtherType, Converted(callback, other_callback), "description"]
-        other_argument: Annotated[Converted[callback, other_callback], "description"],
     ) -> None:
         raise NotImplementedError
     ```
-
-    Where `Converted[...]` follows the same semantics as Converted's `__init__`.
     """
 
     __slots__ = ("_converters",)
@@ -375,6 +374,7 @@ Snowflake = typing.Annotated[hikari.Snowflake, Converted(conversion.parse_snowfl
 
 
 class _DefaultMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass Default(...) too Annotated")
     def __getitem__(cls, value: typing.Union[type[_T], tuple[type[_T], _T]], /) -> type[_T]:
         if isinstance(value, tuple):
             type_ = value[0]
@@ -395,7 +395,6 @@ class Default(_ConfigIdentifier, metaclass=_DefaultMeta):
     async def command(
         ctx: tanjun.abc.Context,
         argument: Annotated[Str, Default(""), "description"],
-        other_argument: Annotated[Default[Str, ""], "description"],
     ) -> None:
         raise NotImplementedError
     ```
@@ -405,8 +404,7 @@ class Default(_ConfigIdentifier, metaclass=_DefaultMeta):
     @tanjun.as_slash_command("name", "description")
     async def command(
         ctx: tanjun.abc.Context,
-        required_argument: Annotated[Default[Str], "description"] = "yeet",
-        other_required: Annotated[Int, Default(), "description"] = 123,
+        required_argument: Annotated[Int, Default(), "description"] = 123,
     ) -> None:
         raise NotImplementedError
     ```
@@ -549,6 +547,7 @@ class Flag(_ConfigIdentifier):
 
 
 class _PositionalMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass Positional(...) too Annotated")
     def __getitem__(cls, type_: type[_T], /) -> type[_T]:
         return typing.cast("type[_T]", typing.Annotated[type_, Positional()])
 
@@ -568,8 +567,7 @@ class Positional(_ConfigIdentifier, metaclass=_PositionalMeta):
     @tanjun.as_message_command("message")
     async def command(
         ctx: tanjun.abc.MessageContext,
-        positional_arg: Positional[Str] = None,
-        other_positional_arg: Annotated[Str, Positional()] = None,
+        positional_arg: Annotated[Str, Positional()] = None,
     ) -> None:
         raise NotImplementedError
     ```
@@ -582,6 +580,7 @@ class Positional(_ConfigIdentifier, metaclass=_PositionalMeta):
 
 
 class _GreedyMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass Greedy(...) too Annotated")
     def __getitem__(cls, type_: type[_T], /) -> type[_T]:
         return typing.cast("type[_T]", typing.Annotated[type_, Greedy()])
 
@@ -600,7 +599,7 @@ class Greedy(_ConfigIdentifier, metaclass=_GreedyMeta):
     @tanjun.as_message_command("message")
     async def command(
         ctx: tanjun.abc.MessageContext,
-        greedy_arg: Greedy[Str],
+        greedy_arg: Annotated[Str, Greedy()],
         other_greedy_arg: Annotated[Str, Greedy()],
     ) -> None:
         raise NotImplementedError
@@ -614,6 +613,7 @@ class Greedy(_ConfigIdentifier, metaclass=_GreedyMeta):
 
 
 class _LengthMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass Length(...) too Annotated")
     def __getitem__(cls, value: typing.Union[int, tuple[int, int]], /) -> type[str]:
         if isinstance(value, int):
             obj = Length(value)
@@ -640,13 +640,9 @@ class Length(_ConfigIdentifier, metaclass=_LengthMeta):
         ctx: tanjun.abc.Context,
         max_and_min: typing.Annotated[Str, Length(123, 321)],
         max_only: typing.Annotated[Str, Length(123)],
-        generic_max_and_min: typing.Annotated[Length[5, 13], "meow"],
-        generic_max_only: typing.Annotated[Length[21], "meow"],
     ) -> None:
         raise NotImplementedError
     ```
-
-    where `Length[...]` follows the same semantics as Length's `__init__`.
 
     ```py
     @with_annotated_args
@@ -713,6 +709,7 @@ class Length(_ConfigIdentifier, metaclass=_LengthMeta):
 
 
 class _MaxMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass Max(...) too Annotated")
     def __getitem__(cls, value: _NumberT, /) -> type[_NumberT]:
         if isinstance(value, int):
             return typing.cast("type[_NumberT]", typing.Annotated[Int, Max(value)])
@@ -731,13 +728,10 @@ class Max(_ConfigIdentifier, metaclass=_MaxMeta):
     async def command(
         ctx: tanjun.abc.Context,
         age: Annotated[Int, Max(130), "How old are you?"],
-        number: Annotated[Max[130.2], "description"],
+        number: Annotated[Float, Max(130.2), "description"],
     ) -> None:
         raise NotImplementedError
     ```
-
-    The option's type is inferred from the passed value when using
-    [Max][tanjun.annotations.Max] as a generic type hint (e.g. `Max[18]`).
     """
 
     __slots__ = ("_value",)
@@ -762,6 +756,7 @@ class Max(_ConfigIdentifier, metaclass=_MaxMeta):
 
 
 class _MinMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass Min(...) too Annotated")
     def __getitem__(cls, value: _NumberT, /) -> type[_NumberT]:
         if isinstance(value, int):
             return typing.cast("type[_NumberT]", typing.Annotated[Int, Min(value)])
@@ -780,13 +775,10 @@ class Min(_ConfigIdentifier, metaclass=_MinMeta):
     async def command(
         ctx: tanjun.abc.Context,
         age: Annotated[Int, Min(13), "How old are you?"],
-        number: Annotated[Min[13.9], "description"],
+        number: Annotated[Float, Min(13.9), "description"],
     ) -> None:
         raise NotImplementedError
     ```
-
-    The option's type is inferred from the passed value when using
-    [Min][tanjun.annotations.Min] as a generic type hint (e.g. `Min[69.4]`).
     """
 
     __slots__ = ("_value",)
@@ -880,6 +872,7 @@ class Name(_ConfigIdentifier):
 
 
 class _RangedMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass Ranged(...) too Annotated")
     def __getitem__(cls, range_: tuple[_NumberT, _NumberT], /) -> type[_NumberT]:
         # This better matches how type checking (well pyright at least) will
         # prefer to go to float if either value is float.
@@ -901,14 +894,10 @@ class Ranged(_ConfigIdentifier, metaclass=_RangedMeta):
     async def command(
         ctx: tanjun.abc.Context,
         number_arg: Annotated[Int, Ranged(0, 69), "description"],
-        other_number_arg: Annotated[Ranged[13.69, 420.69], "description"],
+        other_number_arg: Annotated[Float, Ranged(13.69, 420.69), "description"],
     ) -> None:
         raise NotImplementedError
     ```
-
-    The option's type is inferred from whether integers or floats are passed
-    when using [Ranged][tanjun.annotations.Ranged] as a generic type hint (e.g.
-    `Ranged[123, 666]`).
 
     ```py
     @with_annotated_args
@@ -967,6 +956,7 @@ _SNOWFLAKE_PARSERS: dict[type[typing.Any], collections.Callable[[str], hikari.Sn
 
 
 class _SnowflakeOrMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass SnowflakeOr(...) too Annotated")
     def __getitem__(cls, type_: type[_T], /) -> type[typing.Union[hikari.Snowflake, _T]]:
         for entry in _snoop_annotation_args(type_):
             if not isinstance(entry, _OptionMarker):
@@ -1013,10 +1003,6 @@ class SnowflakeOr(_ConfigIdentifier, metaclass=_SnowflakeOrMeta):
     async def command(
         ctx: tanjun.abc.Context,
         user: Annotated[User, SnowflakeOr(parse_id=parse_user_id), "The user to target."],
-
-        # The `parse_id` callback is automatically set to the mention format for
-        # the passed type if applicable when using SnowflakeOr as a generic type-hint.
-        role: Annotated[Optional[SnowflakeOr[Role]], "The role to target."] = None,
     ) -> None:
         user_id = hikari.Snowflake(user)
     ```
@@ -1057,6 +1043,7 @@ class _TypeOverride(_ConfigIdentifier):
 
 
 class _TheseChannelsMeta(abc.ABCMeta):
+    @typing_extensions.deprecated("Pass TheseChannels(...) too Annotated")
     def __getitem__(
         cls, value: typing.Union[_ChannelTypeIsh, collections.Collection[_ChannelTypeIsh]], /
     ) -> type[hikari.PartialChannel]:
@@ -1475,8 +1462,9 @@ def with_annotated_args(
 
     To declare arguments you will have to do one of two things:
 
-    1. Using any of the following types as an argument's type-hint (this may be as the
-        first argument to [typing.Annotated][]) will mark it as a command argument:
+    1. Using any of the following types as an argument's type-hint (this may
+        be as the first argument to [typing.Annotated][]) will mark it as a
+        command argument:
 
         * [tanjun.annotations.Attachment][]\*
         * [tanjun.annotations.Bool][]
@@ -1515,9 +1503,8 @@ def with_annotated_args(
             raise NotImplementedError
         ```
 
-    2. By assigning [tanjun.annotations.Converted][]...
-
-        Either as one of the other arguments to [typing.Annotated][]
+    2. By assigning [tanjun.annotations.Converted][] as one of the other
+        arguments to [typing.Annotated][]:
 
         ```py
         @tanjun.with_annotated_args(follow_wrapped=True)
@@ -1530,19 +1517,6 @@ def with_annotated_args(
             raise NotImplementedError
         ```
 
-        or as the type hint
-
-        ```py
-        @tanjun.with_annotated_args(follow_wrapped=True)
-        @tanjun.as_message_command("e")
-        @tanjun.as_slash_command("e", "description")
-        async def command(
-            ctx: tanjun.abc.SlashContext,
-            value: Annotated[Converted[CustomType.from_str], "description"],
-        ) -> None:
-            raise NotImplementedError
-        ```
-
     It should be noted that wrapping in [typing.Annotated][] isn't necessary for
     message commands options as they don't have descriptions.
 
@@ -1550,7 +1524,7 @@ def with_annotated_args(
     async def message_command(
         ctx: tanjun.abc.MessageContext,
         name: Str,
-        converted: Converted[Type.from_str],
+        value: Str,
         enable: typing.Optional[Bool] = None,
     ) -> None:
         raise NotImplementedError

--- a/tanjun/annotations.py
+++ b/tanjun/annotations.py
@@ -220,7 +220,7 @@ class _IntEnumConverter(_ConfigIdentifier):
 
 
 class _ChoicesMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass Choices(...) too Annotated")
+    @typing_extensions.deprecated("Pass Choices(...) to Annotated")
     def __getitem__(cls, enum_: type[_EnumT], /) -> type[_EnumT]:
         if issubclass(enum_, float):
             type_ = float
@@ -306,7 +306,7 @@ class Choices(_ConfigIdentifier, metaclass=_ChoicesMeta):
 
 
 class _ConvertedMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass Converted(...) too Annotated")
+    @typing_extensions.deprecated("Pass Converted(...) to Annotated")
     def __getitem__(cls, converters: typing.Union[_ConverterSig[_T], tuple[_ConverterSig[_T]]], /) -> type[_T]:
         if not isinstance(converters, tuple):
             converters = (converters,)
@@ -374,7 +374,7 @@ Snowflake = typing.Annotated[hikari.Snowflake, Converted(conversion.parse_snowfl
 
 
 class _DefaultMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass Default(...) too Annotated")
+    @typing_extensions.deprecated("Pass Default(...) to Annotated")
     def __getitem__(cls, value: typing.Union[type[_T], tuple[type[_T], _T]], /) -> type[_T]:
         if isinstance(value, tuple):
             type_ = value[0]
@@ -547,7 +547,7 @@ class Flag(_ConfigIdentifier):
 
 
 class _PositionalMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass Positional(...) too Annotated")
+    @typing_extensions.deprecated("Pass Positional(...) to Annotated")
     def __getitem__(cls, type_: type[_T], /) -> type[_T]:
         return typing.cast("type[_T]", typing.Annotated[type_, Positional()])
 
@@ -580,7 +580,7 @@ class Positional(_ConfigIdentifier, metaclass=_PositionalMeta):
 
 
 class _GreedyMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass Greedy(...) too Annotated")
+    @typing_extensions.deprecated("Pass Greedy(...) to Annotated")
     def __getitem__(cls, type_: type[_T], /) -> type[_T]:
         return typing.cast("type[_T]", typing.Annotated[type_, Greedy()])
 
@@ -613,7 +613,7 @@ class Greedy(_ConfigIdentifier, metaclass=_GreedyMeta):
 
 
 class _LengthMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass Length(...) too Annotated")
+    @typing_extensions.deprecated("Pass Length(...) to Annotated")
     def __getitem__(cls, value: typing.Union[int, tuple[int, int]], /) -> type[str]:
         if isinstance(value, int):
             obj = Length(value)
@@ -709,7 +709,7 @@ class Length(_ConfigIdentifier, metaclass=_LengthMeta):
 
 
 class _MaxMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass Max(...) too Annotated")
+    @typing_extensions.deprecated("Pass Max(...) to Annotated")
     def __getitem__(cls, value: _NumberT, /) -> type[_NumberT]:
         if isinstance(value, int):
             return typing.cast("type[_NumberT]", typing.Annotated[Int, Max(value)])
@@ -756,7 +756,7 @@ class Max(_ConfigIdentifier, metaclass=_MaxMeta):
 
 
 class _MinMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass Min(...) too Annotated")
+    @typing_extensions.deprecated("Pass Min(...) to Annotated")
     def __getitem__(cls, value: _NumberT, /) -> type[_NumberT]:
         if isinstance(value, int):
             return typing.cast("type[_NumberT]", typing.Annotated[Int, Min(value)])
@@ -872,7 +872,7 @@ class Name(_ConfigIdentifier):
 
 
 class _RangedMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass Ranged(...) too Annotated")
+    @typing_extensions.deprecated("Pass Ranged(...) to Annotated")
     def __getitem__(cls, range_: tuple[_NumberT, _NumberT], /) -> type[_NumberT]:
         # This better matches how type checking (well pyright at least) will
         # prefer to go to float if either value is float.
@@ -956,7 +956,7 @@ _SNOWFLAKE_PARSERS: dict[type[typing.Any], collections.Callable[[str], hikari.Sn
 
 
 class _SnowflakeOrMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass SnowflakeOr(...) too Annotated")
+    @typing_extensions.deprecated("Pass SnowflakeOr(...) to Annotated")
     def __getitem__(cls, type_: type[_T], /) -> type[typing.Union[hikari.Snowflake, _T]]:
         for entry in _snoop_annotation_args(type_):
             if not isinstance(entry, _OptionMarker):
@@ -1043,7 +1043,7 @@ class _TypeOverride(_ConfigIdentifier):
 
 
 class _TheseChannelsMeta(abc.ABCMeta):
-    @typing_extensions.deprecated("Pass TheseChannels(...) too Annotated")
+    @typing_extensions.deprecated("Pass TheseChannels(...) to Annotated")
     def __getitem__(
         cls, value: typing.Union[_ChannelTypeIsh, collections.Collection[_ChannelTypeIsh]], /
     ) -> type[hikari.PartialChannel]:

--- a/tanjun/commands/menu.py
+++ b/tanjun/commands/menu.py
@@ -406,7 +406,8 @@ class MenuCommand(base.PartialCommand[tanjun.MenuContext], tanjun.MenuCommand[_A
     def __init__(
         self,
         callback: _CallbackishT[_AnyMenuCallbackSigT],
-        type_: _MenuTypeT,
+        # TODO: should be _MenuTypeT but pyright broke
+        type_: typing.Any,
         name: typing.Union[str, collections.Mapping[str, str]],
         /,
         *,

--- a/tanjun/conversion.py
+++ b/tanjun/conversion.py
@@ -1029,10 +1029,9 @@ def _make_snowflake_searcher(regex: re.Pattern[str], /) -> _IDSearcherSig:
             if value.isdigit() and _range_check(result := hikari.Snowflake(value)):
                 return [result]
 
-            results = filter(
-                _range_check, map(hikari.Snowflake, (match.groups()[0] for match in regex.finditer(value)))
-            )
-            return [*results, *filter(_range_check, map(hikari.Snowflake, filter(str.isdigit, value.split())))]
+            results = filter(_range_check, (hikari.Snowflake(match.groups()[0]) for match in regex.finditer(value)))
+            other_ids_iter = map(hikari.Snowflake, filter(str.isdigit, value.split()))
+            return [*results, *filter(_range_check, other_ids_iter)]  # pyright: ignore [ reportGeneralTypeIssues ]
 
         try:
             result = hikari.Snowflake(value)
@@ -1506,7 +1505,7 @@ def to_color(argument: _SnowflakeIsh, /) -> hikari.Color:
     return hikari.Color.of(argument)
 
 
-_TYPE_OVERRIDES: dict[collections.Callable[..., typing.Any], collections.Callable[[str], typing.Any]] = {
+_TYPE_OVERRIDES: dict[typing.Any, collections.Callable[[str], typing.Any]] = {
     bool: to_bool,
     bytes: lambda d: bytes(d, "utf-8"),
     bytearray: lambda d: bytearray(d, "utf-8"),

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -5840,7 +5840,7 @@ def test_with_unpacked_typed_dict_and_color():
     assert option.min_length is None
     assert option.max_length is None
     assert option.min_value is None
-    assert option.max_value is None 
+    assert option.max_value is None
 
 
 def test_with_unpacked_typed_dict_and_converted():

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -817,15 +817,17 @@ def test_with_generic_float_choices():
         Blam = 432.123
         Ok = 43.34
 
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        nom: typing.Annotated[annotations.Choices[Choices], "description"],  # type: ignore
-        boom: typing.Annotated[annotations.Choices[Choices], "bag"] = Choices.Blam,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            nom: typing.Annotated[annotations.Choices[Choices], "description"],  # type: ignore
+            boom: typing.Annotated[annotations.Choices[Choices], "bag"] = Choices.Blam,  # type: ignore
+        ):
+            ...
 
     assert callback.build().options == [
         hikari.CommandOption(
@@ -910,15 +912,17 @@ def test_with_generic_int_choices():
         Batman = 123
         Bazman = 0
 
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        nat: typing.Annotated[annotations.Choices[Choices], "meow"],  # type: ignore
-        bag: typing.Annotated[annotations.Choices[Choices], "bagette"] = Choices.Bazman,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            nat: typing.Annotated[annotations.Choices[Choices], "meow"],  # type: ignore
+            bag: typing.Annotated[annotations.Choices[Choices], "bagette"] = Choices.Bazman,  # type: ignore
+        ):
+            ...
 
     assert callback.build().options == [
         hikari.CommandOption(
@@ -1002,15 +1006,17 @@ def test_with_generic_str_choices():
         Sis = "pls"
         Catgirl = "uwu"
 
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        ny: typing.Annotated[annotations.Choices[Choices], "fat"],  # type: ignore
-        aa: typing.Annotated[annotations.Choices[Choices], "bat"] = Choices.Sis,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            ny: typing.Annotated[annotations.Choices[Choices], "fat"],  # type: ignore
+            aa: typing.Annotated[annotations.Choices[Choices], "bat"] = Choices.Sis,  # type: ignore
+        ):
+            ...
 
     assert callback.build().options == [
         hikari.CommandOption(
@@ -1093,7 +1099,9 @@ def test_with_generic_choices_when_enum_has_no_other_base():
     class Choices(enum.Enum):
         ...
 
-    with pytest.raises(TypeError, match="Enum must be a subclass of str, float or int"):
+    with pytest.warns(DeprecationWarning), pytest.raises(
+        TypeError, match="Enum must be a subclass of str, float or int"
+    ):
         annotations.Choices[Choices]
 
 
@@ -1101,7 +1109,9 @@ def test_with_generic_choices_when_enum_isnt_int_str_or_float():
     class Choices(bytes, enum.Enum):
         ...
 
-    with pytest.raises(TypeError, match="Enum must be a subclass of str, float or int"):
+    with pytest.warns(DeprecationWarning), pytest.raises(
+        TypeError, match="Enum must be a subclass of str, float or int"
+    ):
         annotations.Choices[Choices]
 
 
@@ -1294,14 +1304,18 @@ def test_with_default():
 
 
 def test_with_generic_default():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("name", "description")
-    @tanjun.as_message_command("name")
-    async def command(
-        ctx: tanjun.abc.Context,
-        argument: typing.Annotated[annotations.Default[annotations.Str, "nyaa"], "meow"],  # noqa: F821  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("name", "description")
+        @tanjun.as_message_command("name")
+        async def command(
+            ctx: tanjun.abc.Context,
+            argument: typing.Annotated[
+                annotations.Default[annotations.Str, "nyaa"], "meow"  # noqa: F821  # type: ignore
+            ],
+        ) -> None:
+            ...
 
     assert command.build().options == [
         hikari.CommandOption(
@@ -1594,13 +1608,15 @@ def test_with_positional():
 
 
 def test_with_generic_positional():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("name")
-    @tanjun.as_slash_command("boop", "description")
-    async def callback(
-        ctx: tanjun.abc.Context, beep: typing.Annotated[annotations.Positional[annotations.Str], "eat"]  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("name")
+        @tanjun.as_slash_command("boop", "description")
+        async def callback(
+            ctx: tanjun.abc.Context, beep: typing.Annotated[annotations.Positional[annotations.Str], "eat"]  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -1647,10 +1663,12 @@ def test_with_greedy():
 
 
 def test_with_generic_greedy():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    async def callback(ctx: tanjun.abc.Context, meep: annotations.Greedy[annotations.Str]):  # type: ignore
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        async def callback(ctx: tanjun.abc.Context, meep: annotations.Greedy[annotations.Str]):  # type: ignore
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert len(callback.parser.arguments) == 1
@@ -1827,15 +1845,17 @@ def test_with_length_when_min_specificed():
 
 
 def test_with_generic_length():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("name", "description")
-    @tanjun.as_message_command("name")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.Length[123], "nom"],  # type: ignore
-        other_value: typing.Annotated[typing.Optional[annotations.Length[5544]], "meow"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("name", "description")
+        @tanjun.as_message_command("name")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.Length[123], "nom"],  # type: ignore
+            other_value: typing.Annotated[typing.Optional[annotations.Length[5544]], "meow"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert callback.build().options == [
         hikari.CommandOption(
@@ -1907,15 +1927,17 @@ def test_with_generic_length():
 
 
 def test_with_generic_length_when_min_specificed():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("name", "description")
-    @tanjun.as_message_command("name")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.Length[43, 5444], "nom"],  # type: ignore
-        other_value: typing.Annotated[typing.Optional[annotations.Length[32, 4343]], "meow"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("name", "description")
+        @tanjun.as_message_command("name")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.Length[43, 5444], "nom"],  # type: ignore
+            other_value: typing.Annotated[typing.Optional[annotations.Length[32, 4343]], "meow"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert callback.build().options == [
         hikari.CommandOption(
@@ -1986,26 +2008,14 @@ def test_with_generic_length_when_min_specificed():
     assert option.max_value is None
 
 
-@pytest.mark.parametrize(
-    ("type_", "value", "raw_type", "option_type"),
-    [
-        (annotations.Int, 543, int, hikari.OptionType.INTEGER),
-        (annotations.Float, 234.432, float, hikari.OptionType.FLOAT),
-    ],
-)
-def test_with_max(
-    type_: type[typing.Union[int, float]],
-    value: typing.Union[int, float],
-    raw_type: type[typing.Any],
-    option_type: hikari.OptionType,
-):
+def test_with_int_max():
     @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_slash_command("command", "description")
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
-        bee: typing.Annotated[type_, annotations.Max(value), "eee"],
-        yeet_no: typing.Annotated[typing.Union[type_, None], annotations.Max(value), "eep"] = None,
+        bee: typing.Annotated[annotations.Int, annotations.Max(543), "eee"],
+        yeet_no: typing.Annotated[typing.Union[annotations.Int, None], annotations.Max(543), "eep"] = None,
     ):
         ...
 
@@ -2013,22 +2023,22 @@ def test_with_max(
     assert isinstance(callback.wrapped_command.parser, tanjun.ShlexParser)
     assert callback.build().options == [
         hikari.CommandOption(
-            type=option_type,
+            type=hikari.OptionType.INTEGER,
             name="bee",
             channel_types=None,
             description="eee",
             is_required=True,
             min_value=None,
-            max_value=value,
+            max_value=543,
         ),
         hikari.CommandOption(
-            type=option_type,
+            type=hikari.OptionType.INTEGER,
             name="yeet_no",
             channel_types=None,
             description="eep",
             is_required=False,
             min_value=None,
-            max_value=value,
+            max_value=543,
         ),
     ]
 
@@ -2036,45 +2046,124 @@ def test_with_max(
     tracked_option = callback._tracked_options["bee"]
     assert tracked_option.converters == []
     assert tracked_option.default is tanjun.abc.NO_DEFAULT
-    assert tracked_option.is_always_float is (raw_type is float)
+    assert tracked_option.is_always_float is False
     assert tracked_option.is_only_member is False
     assert tracked_option.key == "bee"
     assert tracked_option.name == "bee"
-    assert tracked_option.type is option_type
+    assert tracked_option.type is hikari.OptionType.INTEGER
 
     tracked_option = callback._tracked_options["yeet_no"]
     assert tracked_option.converters == []
     assert tracked_option.default is tanjun.abc.NO_PASS
-    assert tracked_option.is_always_float is (raw_type is float)
+    assert tracked_option.is_always_float is False
     assert tracked_option.is_only_member is False
     assert tracked_option.key == "yeet_no"
     assert tracked_option.name == "yeet_no"
-    assert tracked_option.type is option_type
+    assert tracked_option.type is hikari.OptionType.INTEGER
 
     assert len(callback.wrapped_command.parser.arguments) == 1
     argument = callback.wrapped_command.parser.arguments[0]
     assert argument.key == "bee"
-    assert argument.converters == [raw_type]
+    assert argument.converters == [int]
     assert argument.default is tanjun.abc.NO_DEFAULT
     assert argument.is_greedy is False
     assert argument.is_multi is False
     assert argument.min_length is None
     assert argument.max_length is None
     assert argument.min_value is None
-    assert argument.max_value == value
+    assert argument.max_value == 543
 
     assert len(callback.wrapped_command.parser.options) == 1
     option = callback.wrapped_command.parser.options[0]
     assert option.key == "yeet_no"
     assert option.names == ["--yeet-no"]
-    assert option.converters == [raw_type]
+    assert option.converters == [int]
     assert option.default is tanjun.abc.NO_PASS
     assert option.empty_value is tanjun.abc.NO_DEFAULT
     assert option.is_multi is False
     assert option.min_length is None
     assert option.max_length is None
     assert option.min_value is None
-    assert option.max_value == value
+    assert option.max_value == 543
+
+
+def test_with_float_max():
+    @annotations.with_annotated_args(follow_wrapped=True)
+    @tanjun.as_slash_command("command", "description")
+    @tanjun.as_message_command("command")
+    async def callback(
+        ctx: tanjun.abc.Context,
+        bee: typing.Annotated[annotations.Float, annotations.Max(234.432), "eee"],
+        yeet_no: typing.Annotated[typing.Union[annotations.Float, None], annotations.Max(234.432), "eep"] = None,
+    ):
+        ...
+
+    assert isinstance(callback.wrapped_command, tanjun.MessageCommand)
+    assert isinstance(callback.wrapped_command.parser, tanjun.ShlexParser)
+    assert callback.build().options == [
+        hikari.CommandOption(
+            type=hikari.OptionType.FLOAT,
+            name="bee",
+            channel_types=None,
+            description="eee",
+            is_required=True,
+            min_value=None,
+            max_value=234.432,
+        ),
+        hikari.CommandOption(
+            type=hikari.OptionType.FLOAT,
+            name="yeet_no",
+            channel_types=None,
+            description="eep",
+            is_required=False,
+            min_value=None,
+            max_value=234.432,
+        ),
+    ]
+
+    assert len(callback._tracked_options) == 2
+    tracked_option = callback._tracked_options["bee"]
+    assert tracked_option.converters == []
+    assert tracked_option.default is tanjun.abc.NO_DEFAULT
+    assert tracked_option.is_always_float is True
+    assert tracked_option.is_only_member is False
+    assert tracked_option.key == "bee"
+    assert tracked_option.name == "bee"
+    assert tracked_option.type is hikari.OptionType.FLOAT
+
+    tracked_option = callback._tracked_options["yeet_no"]
+    assert tracked_option.converters == []
+    assert tracked_option.default is tanjun.abc.NO_PASS
+    assert tracked_option.is_always_float is True
+    assert tracked_option.is_only_member is False
+    assert tracked_option.key == "yeet_no"
+    assert tracked_option.name == "yeet_no"
+    assert tracked_option.type is hikari.OptionType.FLOAT
+
+    assert len(callback.wrapped_command.parser.arguments) == 1
+    argument = callback.wrapped_command.parser.arguments[0]
+    assert argument.key == "bee"
+    assert argument.converters == [float]
+    assert argument.default is tanjun.abc.NO_DEFAULT
+    assert argument.is_greedy is False
+    assert argument.is_multi is False
+    assert argument.min_length is None
+    assert argument.max_length is None
+    assert argument.min_value is None
+    assert argument.max_value == 234.432
+
+    assert len(callback.wrapped_command.parser.options) == 1
+    option = callback.wrapped_command.parser.options[0]
+    assert option.key == "yeet_no"
+    assert option.names == ["--yeet-no"]
+    assert option.converters == [float]
+    assert option.default is tanjun.abc.NO_PASS
+    assert option.empty_value is tanjun.abc.NO_DEFAULT
+    assert option.is_multi is False
+    assert option.min_length is None
+    assert option.max_length is None
+    assert option.min_value is None
+    assert option.max_value == 234.432
 
 
 @pytest.mark.parametrize(
@@ -2084,15 +2173,17 @@ def test_with_max(
 def test_with_generic_max(
     value: typing.Union[int, float], converter: typing.Union[type[int], type[float]], option_type: hikari.OptionType
 ):
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        number: typing.Annotated[annotations.Max[value], "eee"],  # type: ignore
-        other_number: typing.Annotated[annotations.Max[value], "eep"] = 54234,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            number: typing.Annotated[annotations.Max[value], "eee"],  # type: ignore
+            other_number: typing.Annotated[annotations.Max[value], "eep"] = 54234,  # type: ignore
+        ):
+            ...
 
     assert isinstance(callback.wrapped_command, tanjun.MessageCommand)
     assert isinstance(callback.wrapped_command.parser, tanjun.ShlexParser)
@@ -2351,15 +2442,17 @@ def test_with_min(
 def test_with_generic_min(
     value: typing.Union[int, float], converter: typing.Union[type[int], type[float]], option_type: hikari.OptionType
 ):
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        number: typing.Annotated[annotations.Min[value], "bee"],  # type: ignore
-        other_number: typing.Annotated[annotations.Min[value], "buzz"] = 321,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            number: typing.Annotated[annotations.Min[value], "bee"],  # type: ignore
+            other_number: typing.Annotated[annotations.Min[value], "buzz"] = 321,  # type: ignore
+        ):
+            ...
 
     assert isinstance(callback.wrapped_command, tanjun.MessageCommand)
     assert isinstance(callback.wrapped_command.parser, tanjun.ShlexParser)
@@ -2884,15 +2977,17 @@ def test_with_generic_ranged(
     converter: typing.Union[type[float], type[int]],
     option_type: hikari.OptionType,
 ):
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        number: typing.Annotated[annotations.Ranged[min_value, max_value], "meow"],  # type: ignore
-        other_number: typing.Annotated[annotations.Ranged[min_value, max_value], "nom"] = 443,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            number: typing.Annotated[annotations.Ranged[min_value, max_value], "meow"],  # type: ignore
+            other_number: typing.Annotated[annotations.Ranged[min_value, max_value], "nom"] = 443,  # type: ignore
+        ):
+            ...
 
     assert isinstance(callback.wrapped_command, tanjun.MessageCommand)
     assert isinstance(callback.wrapped_command.parser, tanjun.ShlexParser)
@@ -3045,15 +3140,17 @@ def test_with_snowflake_or():
 
 
 def test_with_generic_snowflake_or_for_channel():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Channel], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Channel]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.Channel], "se"],  # type: ignore
+            value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Channel]], "x"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3125,15 +3222,17 @@ def test_with_generic_snowflake_or_for_channel():
 
 
 def test_with_generic_snowflake_or_for_member():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Member], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Member]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.Member], "se"],  # type: ignore
+            value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Member]], "x"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3205,15 +3304,19 @@ def test_with_generic_snowflake_or_for_member():
 
 
 def test_with_generic_snowflake_or_for_mentionable():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Mentionable], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Mentionable]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.Mentionable], "se"],  # type: ignore
+            value_2: typing.Annotated[
+                annotations.SnowflakeOr[typing.Optional[annotations.Mentionable]], "x"  # type: ignore
+            ] = None,
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3285,15 +3388,17 @@ def test_with_generic_snowflake_or_for_mentionable():
 
 
 def test_with_generic_snowflake_or_for_role():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Role], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Role]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.Role], "se"],  # type: ignore
+            value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Role]], "x"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3365,15 +3470,17 @@ def test_with_generic_snowflake_or_for_role():
 
 
 def test_with_generic_snowflake_or_for_user():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.User], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.User]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.User], "se"],  # type: ignore
+            value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.User]], "x"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3445,15 +3552,17 @@ def test_with_generic_snowflake_or_for_user():
 
 
 def test_with_generic_snowflake_or():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Bool], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Bool]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.Bool], "se"],  # type: ignore
+            value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Bool]], "x"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3644,18 +3753,20 @@ def test_with_these_channels(
     assert option.max_value is None
 
 
-def test_with_generic_these_channels():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("name", "description")
-    @tanjun.as_message_command("name")
-    async def command(
-        ctx: tanjun.abc.Context,
-        bb: typing.Annotated[annotations.TheseChannels[hikari.GuildChannel], "nep"],  # type: ignore
-        bat: typing.Annotated[
-            typing.Optional[annotations.TheseChannels[hikari.GuildVoiceChannel, hikari.PrivateChannel]], "bip"  # type: ignore
-        ] = None,
-    ):
-        ...
+def test_with_generic_these_channels():  # noqa: CFQ001
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("name", "description")
+        @tanjun.as_message_command("name")
+        async def command(
+            ctx: tanjun.abc.Context,
+            bb: typing.Annotated[annotations.TheseChannels[hikari.GuildChannel], "nep"],  # type: ignore
+            bat: typing.Annotated[
+                typing.Optional[annotations.TheseChannels[hikari.GuildVoiceChannel, hikari.PrivateChannel]], "bip"  # type: ignore
+            ] = None,
+        ):
+            ...
 
     expected_types_1 = {
         hikari.ChannelType.GUILD_CATEGORY,

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -5840,7 +5840,7 @@ def test_with_unpacked_typed_dict_and_color():
     assert option.min_length is None
     assert option.max_length is None
     assert option.min_value is None
-    assert option.max_value is None
+    assert option.max_value is None 
 
 
 def test_with_unpacked_typed_dict_and_converted():

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -3313,7 +3313,7 @@ def test_with_generic_snowflake_or_for_mentionable():
             ctx: tanjun.abc.Context,
             value: typing.Annotated[annotations.SnowflakeOr[annotations.Mentionable], "se"],  # type: ignore
             value_2: typing.Annotated[
-                annotations.SnowflakeOr[typing.Optional[annotations.Mentionable]], "x"  # type: ignore
+                typing.Optional[annotations.SnowflakeOr[annotations.Mentionable]], "x"  # type: ignore
             ] = None,
         ) -> None:
             ...

--- a/tests/test_annotations_future_annotations.py
+++ b/tests/test_annotations_future_annotations.py
@@ -696,8 +696,8 @@ def test_with_generic_float_choices():
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
-        nom: typing.Annotated[annotations.Choices[Choices1], "description"],
-        boom: typing.Annotated[annotations.Choices[Choices1], "bag"] = Choices1.Blam,
+        nom: typing.Annotated[annotations.Choices[Choices1], "description"],  # type: ignore
+        boom: typing.Annotated[annotations.Choices[Choices1], "bag"] = Choices1.Blam,  # type: ignore
     ):
         ...
 
@@ -791,8 +791,8 @@ def test_with_generic_int_choices():
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
-        nat: typing.Annotated[annotations.Choices[Choices2], "meow"],
-        bag: typing.Annotated[annotations.Choices[Choices2], "bagette"] = Choices2.Bazman,
+        nat: typing.Annotated[annotations.Choices[Choices2], "meow"],  # type: ignore
+        bag: typing.Annotated[annotations.Choices[Choices2], "bagette"] = Choices2.Bazman,  # type: ignore
     ):
         ...
 
@@ -885,8 +885,8 @@ def test_with_generic_str_choices():
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
-        ny: typing.Annotated[annotations.Choices[Choices3], "fat"],
-        aa: typing.Annotated[annotations.Choices[Choices3], "bat"] = Choices3.Sis,
+        ny: typing.Annotated[annotations.Choices[Choices3], "fat"],  # type: ignore
+        aa: typing.Annotated[annotations.Choices[Choices3], "bat"] = Choices3.Sis,  # type: ignore
     ):
         ...
 
@@ -1074,7 +1074,7 @@ def test_with_generic_converted():
     async def command(
         ctx: tanjun.abc.Context,
         boo: typing.Annotated[annotations.Converted[mock_callback_1, mock_callback_2], "description"],  # type: ignore
-        bam: typing.Annotated[annotations.Converted[mock_callback_3], "nom"] = None,
+        bam: typing.Annotated[annotations.Converted[mock_callback_3], "nom"] = None,  # type: ignore
     ) -> None:
         ...
 
@@ -1183,7 +1183,7 @@ def test_with_generic_default():
     @tanjun.as_message_command("name")
     async def command(
         ctx: tanjun.abc.Context,
-        argument: typing.Annotated[annotations.Default[annotations.Str, "nyaa"], "meow"],  # noqa: F821
+        argument: typing.Annotated[annotations.Default[annotations.Str, "nyaa"], "meow"],  # noqa: F821  #type: ignore
     ) -> None:
         ...
 
@@ -1226,7 +1226,7 @@ def test_with_default_overriding_signature_default():
     @tanjun.as_message_command("name")
     async def command(
         ctx: tanjun.abc.Context,
-        argument: typing.Annotated[annotations.Default[annotations.Str, "yeet"], "meow"] = "m",  # noqa: F821
+        argument: typing.Annotated[annotations.Str, annotations.Default("yeet"), "meow"] = "m",  # noqa: F821
     ) -> None:
         ...
 
@@ -1268,7 +1268,7 @@ def test_with_default_unsetting_signature_default():
     @tanjun.as_slash_command("name", "description")
     @tanjun.as_message_command("name")
     async def command(
-        ctx: tanjun.abc.Context, argument: typing.Annotated[annotations.Default[annotations.Str], "meow"] = "m"
+        ctx: tanjun.abc.Context, argument: typing.Annotated[annotations.Str, annotations.Default(), "meow"] = "m"
     ) -> None:
         ...
 
@@ -1372,7 +1372,9 @@ def test_with_flag_and_deprecated_default():
         @tanjun.as_slash_command("beep", "boop")
         async def callback(
             ctx: tanjun.abc.Context,
-            eep: typing.Annotated[annotations.Int, annotations.Flag(default=1231), "b"] = 545454,
+            eep: typing.Annotated[
+                annotations.Int, annotations.Flag(default=1231), "b"  # pyright: ignore [ reportDeprecated ]
+            ] = 545454,
         ) -> None:
             ...
 
@@ -1476,6 +1478,39 @@ def test_with_positional():
     assert option.default is tanjun.abc.NO_DEFAULT
 
 
+def test_with_generic_positional():
+    @annotations.with_annotated_args(follow_wrapped=True)
+    @tanjun.as_message_command("name")
+    @tanjun.as_slash_command("boop", "description")
+    async def callback(
+        ctx: tanjun.abc.Context, beep: typing.Annotated[annotations.Positional[annotations.Str], "eat"]  # type: ignore
+    ) -> None:
+        ...
+
+    assert isinstance(callback.parser, tanjun.ShlexParser)
+    assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
+    assert len(callback.parser.arguments) == 1
+    assert len(callback.parser.options) == 0
+    option = callback.parser.arguments[0]
+    assert option.key == "beep"
+    assert option.converters == []
+    assert option.default is tanjun.abc.NO_DEFAULT
+    assert option.is_multi is False
+    assert option.min_length is None
+    assert option.max_length is None
+    assert option.min_value is None
+    assert option.max_value is None
+
+    assert callback.wrapped_command.build().options == [
+        hikari.CommandOption(
+            type=hikari.OptionType.STRING, name="beep", channel_types=None, description="eat", is_required=True
+        )
+    ]
+    assert len(callback.wrapped_command._tracked_options) == 1
+    option = callback.wrapped_command._tracked_options["beep"]
+    assert option.default is tanjun.abc.NO_DEFAULT
+
+
 def test_with_greedy():
     @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
@@ -1499,7 +1534,7 @@ def test_with_greedy():
 def test_with_generic_greedy():
     @annotations.with_annotated_args(follow_wrapped=True)
     @tanjun.as_message_command("command")
-    async def callback(ctx: tanjun.abc.Context, meep: annotations.Greedy[annotations.Str]):
+    async def callback(ctx: tanjun.abc.Context, meep: annotations.Greedy[annotations.Str]):  # type: ignore
         ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
@@ -1682,8 +1717,8 @@ def test_with_generic_length():
     @tanjun.as_message_command("name")
     async def callback(
         ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.Length[123], "nom"],
-        other_value: typing.Annotated[typing.Optional[annotations.Length[5544]], "meow"] = None,
+        value: typing.Annotated[annotations.Length[123], "nom"],  # type: ignore
+        other_value: typing.Annotated[typing.Optional[annotations.Length[5544]], "meow"] = None,  # type: ignore
     ) -> None:
         ...
 
@@ -1762,8 +1797,8 @@ def test_with_generic_length_when_min_specificed():
     @tanjun.as_message_command("name")
     async def callback(
         ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.Length[43, 5444], "nom"],
-        other_value: typing.Annotated[typing.Optional[annotations.Length[32, 4343]], "meow"] = None,
+        value: typing.Annotated[annotations.Length[43, 5444], "nom"],  # type: ignore
+        other_value: typing.Annotated[typing.Optional[annotations.Length[32, 4343]], "meow"] = None,  # type: ignore
     ) -> None:
         ...
 
@@ -1947,8 +1982,8 @@ def test_with_generic_max(
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
-        number: typing.Annotated[annotations.Max[value_], "eee"],
-        other_number: typing.Annotated[annotations.Max[value_], "eep"] = 54234,
+        number: typing.Annotated[annotations.Max[value_], "eee"],  # type: ignore
+        other_number: typing.Annotated[annotations.Max[value_], "eep"] = 54234,  # type: ignore
     ):
         ...
 
@@ -2222,8 +2257,8 @@ def test_with_generic_min(
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
-        number: typing.Annotated[annotations.Min[value_], "bee"],
-        other_number: typing.Annotated[annotations.Min[value_], "buzz"] = 321,
+        number: typing.Annotated[annotations.Min[value_], "bee"],  # type: ignore
+        other_number: typing.Annotated[annotations.Min[value_], "buzz"] = 321,  # type: ignore
     ):
         ...
 
@@ -2760,8 +2795,8 @@ def test_with_generic_ranged(
     @tanjun.as_message_command("command")
     async def callback(
         ctx: tanjun.abc.Context,
-        number: typing.Annotated[annotations.Ranged[min_value_, max_value_], "meow"],
-        other_number: typing.Annotated[annotations.Ranged[min_value_, max_value_], "nom"] = 443,
+        number: typing.Annotated[annotations.Ranged[min_value_, max_value_], "meow"],  # type: ignore
+        other_number: typing.Annotated[annotations.Ranged[min_value_, max_value_], "nom"] = 443,  # type: ignore
     ):
         ...
 
@@ -2922,8 +2957,8 @@ def test_with_generic_snowflake_or_for_channel():
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
         ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Channel], "se"],
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Channel]], "x"] = None,
+        value: typing.Annotated[annotations.SnowflakeOr[annotations.Channel], "se"],  # type: ignore
+        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Channel]], "x"] = None,  # type: ignore
     ) -> None:
         ...
 
@@ -3002,8 +3037,8 @@ def test_with_generic_snowflake_or_for_member():
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
         ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Member], "se"],
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Member]], "x"] = None,
+        value: typing.Annotated[annotations.SnowflakeOr[annotations.Member], "se"],  # type: ignore
+        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Member]], "x"] = None,  # type: ignore
     ) -> None:
         ...
 
@@ -3082,8 +3117,8 @@ def test_with_generic_snowflake_or_for_mentionable():
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
         ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Mentionable], "se"],
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Mentionable]], "x"] = None,
+        value: typing.Annotated[annotations.SnowflakeOr[annotations.Mentionable], "se"],  # type: ignore
+        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Mentionable]], "x"] = None,  # type: ignore
     ) -> None:
         ...
 
@@ -3162,8 +3197,8 @@ def test_with_generic_snowflake_or_for_role():
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
         ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Role], "se"],
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Role]], "x"] = None,
+        value: typing.Annotated[annotations.SnowflakeOr[annotations.Role], "se"],  # type: ignore
+        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Role]], "x"] = None,  # type: ignore
     ) -> None:
         ...
 
@@ -3242,8 +3277,8 @@ def test_with_generic_snowflake_or_for_user():
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
         ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.User], "se"],
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.User]], "x"] = None,
+        value: typing.Annotated[annotations.SnowflakeOr[annotations.User], "se"],  # type: ignore
+        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.User]], "x"] = None,  # type: ignore
     ) -> None:
         ...
 
@@ -3322,8 +3357,8 @@ def test_with_generic_snowflake_or():
     @tanjun.as_slash_command("yeet", "description")
     async def callback(
         ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Bool], "se"],
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Bool]], "x"] = None,
+        value: typing.Annotated[annotations.SnowflakeOr[annotations.Bool], "se"],  # type: ignore
+        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Bool]], "x"] = None,  # type: ignore
     ) -> None:
         ...
 
@@ -3525,9 +3560,9 @@ def test_with_generic_these_channels():
     @tanjun.as_message_command("name")
     async def command(
         ctx: tanjun.abc.Context,
-        bb: typing.Annotated[annotations.TheseChannels[hikari.GuildChannel], "nep"],
+        bb: typing.Annotated[annotations.TheseChannels[hikari.GuildChannel], "nep"],  # type: ignore
         bat: typing.Annotated[
-            typing.Optional[annotations.TheseChannels[hikari.GuildVoiceChannel, hikari.PrivateChannel]], "bip"
+            typing.Optional[annotations.TheseChannels[hikari.GuildVoiceChannel, hikari.PrivateChannel]], "bip"  # type: ignore
         ] = None,
     ):
         ...
@@ -4610,8 +4645,8 @@ def test_when_annotated_not_top_level():
     async def command(
         ctx: tanjun.abc.Context,
         *,
-        value: typing.Union[typing.Annotated[annotations.Positional[annotations.Str], "nyaa"], bool] = False,
-        other_value: typing.Optional[typing.Annotated[annotations.Ranged[123, 432], "meow"]] = None,
+        value: typing.Union[typing.Annotated[annotations.Str, annotations.Positional(), "nyaa"], bool] = False,
+        other_value: typing.Optional[typing.Annotated[annotations.Int, "meow"]] = None,
     ) -> None:
         raise NotImplementedError
 
@@ -4622,8 +4657,8 @@ def test_when_annotated_not_top_level():
             name="other_value",
             description="meow",
             is_required=False,
-            min_value=123,
-            max_value=432,
+            min_value=None,
+            max_value=None,
         ),
     ]
 
@@ -4671,8 +4706,8 @@ def test_when_annotated_not_top_level():
     assert option.is_multi is False
     assert option.min_length is None
     assert option.max_length is None
-    assert option.min_value == 123
-    assert option.max_value == 432
+    assert option.min_value is None
+    assert option.max_value is None
 
 
 if sys.version_info >= (3, 10):
@@ -4684,8 +4719,8 @@ if sys.version_info >= (3, 10):
         async def command(
             ctx: tanjun.abc.Context,
             *,
-            value: typing.Annotated[annotations.Positional[annotations.Str], "nyaa"] | bool = False,
-            other_value: typing.Annotated[annotations.Ranged[123, 432], "meow"] | None = None,
+            value: typing.Annotated[annotations.Str, annotations.Positional(), "nyaa"] | bool = False,
+            other_value: typing.Annotated[annotations.Int, "meow"] | None = None,
         ) -> None:
             raise NotImplementedError
 
@@ -4696,8 +4731,8 @@ if sys.version_info >= (3, 10):
                 name="other_value",
                 description="meow",
                 is_required=False,
-                min_value=123,
-                max_value=432,
+                min_value=None,
+                max_value=None,
             ),
         ]
 
@@ -4745,8 +4780,8 @@ if sys.version_info >= (3, 10):
         assert option.is_multi is False
         assert option.min_length is None
         assert option.max_length is None
-        assert option.min_value == 123
-        assert option.max_value == 432
+        assert option.min_value is None
+        assert option.max_value is None
 
 
 def test_when_annotated_handles_unions():
@@ -4756,8 +4791,8 @@ def test_when_annotated_handles_unions():
     async def command(
         ctx: tanjun.abc.Context,
         *,
-        value: typing.Annotated[typing.Union[annotations.Positional[annotations.Str], bool], "nyaa"] = False,
-        other_value: typing.Annotated[typing.Optional[annotations.Ranged[123, 432]], "meow"] = None,
+        value: typing.Annotated[typing.Union[annotations.Str, bool], annotations.Positional(), "nyaa"] = False,
+        other_value: typing.Annotated[typing.Optional[annotations.Int], "meow"] = None,
     ) -> None:
         raise NotImplementedError
 
@@ -4768,8 +4803,8 @@ def test_when_annotated_handles_unions():
             name="other_value",
             description="meow",
             is_required=False,
-            min_value=123,
-            max_value=432,
+            min_value=None,
+            max_value=None,
         ),
     ]
 
@@ -4817,8 +4852,8 @@ def test_when_annotated_handles_unions():
     assert option.is_multi is False
     assert option.min_length is None
     assert option.max_length is None
-    assert option.min_value == 123
-    assert option.max_value == 432
+    assert option.min_value is None
+    assert option.max_value is None
 
 
 if sys.version_info >= (3, 10):
@@ -4830,8 +4865,8 @@ if sys.version_info >= (3, 10):
         async def command(
             ctx: tanjun.abc.Context,
             *,
-            value: typing.Annotated[annotations.Positional[annotations.Str] | bool, "nyaa"] = False,
-            other_value: typing.Annotated[annotations.Ranged[123, 432] | None, "meow"] = None,
+            value: typing.Annotated[annotations.Str | bool, annotations.Positional(), "nyaa"] = False,
+            other_value: typing.Annotated[annotations.Int | None, "meow"] = None,
         ) -> None:
             raise NotImplementedError
 
@@ -4842,8 +4877,8 @@ if sys.version_info >= (3, 10):
                 name="other_value",
                 description="meow",
                 is_required=False,
-                min_value=123,
-                max_value=432,
+                min_value=None,
+                max_value=None,
             ),
         ]
 
@@ -4891,15 +4926,13 @@ if sys.version_info >= (3, 10):
         assert option.is_multi is False
         assert option.min_length is None
         assert option.max_length is None
-        assert option.min_value == 123
-        assert option.max_value == 432
+        assert option.min_value is None
+        assert option.max_value is None
 
 
 def test_parse_annotated_args_with_descriptions_argument():
     @tanjun.as_slash_command("name", "description")
-    async def command(
-        ctx: tanjun.abc.Context, *, echo: annotations.Str, foxy: annotations.Ranged[123, 432] = 232
-    ) -> None:
+    async def command(ctx: tanjun.abc.Context, *, echo: annotations.Str, foxy: annotations.Int = 232) -> None:
         raise NotImplementedError
 
     annotations.parse_annotated_args(command, descriptions={"echo": "meow", "foxy": "x3", "unknown": "..."})
@@ -4911,8 +4944,8 @@ def test_parse_annotated_args_with_descriptions_argument():
             name="foxy",
             description="x3",
             is_required=False,
-            min_value=123,
-            max_value=432,
+            min_value=None,
+            max_value=None,
         ),
     ]
 

--- a/tests/test_annotations_future_annotations.py
+++ b/tests/test_annotations_future_annotations.py
@@ -691,15 +691,17 @@ def test_with_generic_float_choices():
         Blam = 432.123
         Ok = 43.34
 
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        nom: typing.Annotated[annotations.Choices[Choices1], "description"],  # type: ignore
-        boom: typing.Annotated[annotations.Choices[Choices1], "bag"] = Choices1.Blam,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            nom: typing.Annotated[annotations.Choices[Choices1], "description"],  # type: ignore
+            boom: typing.Annotated[annotations.Choices[Choices1], "bag"] = Choices1.Blam,  # type: ignore
+        ):
+            ...
 
     assert callback.build().options == [
         hikari.CommandOption(
@@ -786,15 +788,17 @@ def test_with_generic_int_choices():
         Batman = 123
         Bazman = 0
 
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        nat: typing.Annotated[annotations.Choices[Choices2], "meow"],  # type: ignore
-        bag: typing.Annotated[annotations.Choices[Choices2], "bagette"] = Choices2.Bazman,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            nat: typing.Annotated[annotations.Choices[Choices2], "meow"],  # type: ignore
+            bag: typing.Annotated[annotations.Choices[Choices2], "bagette"] = Choices2.Bazman,  # type: ignore
+        ):
+            ...
 
     assert callback.build().options == [
         hikari.CommandOption(
@@ -880,15 +884,17 @@ def test_with_generic_str_choices():
         Sis = "pls"
         Catgirl = "uwu"
 
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        ny: typing.Annotated[annotations.Choices[Choices3], "fat"],  # type: ignore
-        aa: typing.Annotated[annotations.Choices[Choices3], "bat"] = Choices3.Sis,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            ny: typing.Annotated[annotations.Choices[Choices3], "fat"],  # type: ignore
+            aa: typing.Annotated[annotations.Choices[Choices3], "bat"] = Choices3.Sis,  # type: ignore
+        ):
+            ...
 
     assert callback.build().options == [
         hikari.CommandOption(
@@ -971,7 +977,9 @@ def test_with_generic_choices_when_enum_has_no_other_base():
     class Choices(enum.Enum):
         ...
 
-    with pytest.raises(TypeError, match="Enum must be a subclass of str, float or int"):
+    with pytest.warns(DeprecationWarning), pytest.raises(
+        TypeError, match="Enum must be a subclass of str, float or int"
+    ):
         annotations.Choices[Choices]
 
 
@@ -979,7 +987,9 @@ def test_with_generic_choices_when_enum_isnt_int_str_or_float():
     class Choices(bytes, enum.Enum):
         ...
 
-    with pytest.raises(TypeError, match="Enum must be a subclass of str, float or int"):
+    with pytest.warns(DeprecationWarning), pytest.raises(
+        TypeError, match="Enum must be a subclass of str, float or int"
+    ):
         annotations.Choices[Choices]
 
 
@@ -1068,15 +1078,17 @@ def test_with_generic_converted():
     mock_callback_2 = mock.Mock()
     mock_callback_3 = mock.Mock()
 
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("nyaa", "meow")
-    @tanjun.as_message_command("nyaa")
-    async def command(
-        ctx: tanjun.abc.Context,
-        boo: typing.Annotated[annotations.Converted[mock_callback_1, mock_callback_2], "description"],  # type: ignore
-        bam: typing.Annotated[annotations.Converted[mock_callback_3], "nom"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("nyaa", "meow")
+        @tanjun.as_message_command("nyaa")
+        async def command(
+            ctx: tanjun.abc.Context,
+            boo: typing.Annotated[annotations.Converted[mock_callback_1, mock_callback_2], "description"],  # type: ignore
+            bam: typing.Annotated[annotations.Converted[mock_callback_3], "nom"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert command.build().options == [
         hikari.CommandOption(
@@ -1178,14 +1190,18 @@ def test_with_default():
 
 
 def test_with_generic_default():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("name", "description")
-    @tanjun.as_message_command("name")
-    async def command(
-        ctx: tanjun.abc.Context,
-        argument: typing.Annotated[annotations.Default[annotations.Str, "nyaa"], "meow"],  # noqa: F821  #type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("name", "description")
+        @tanjun.as_message_command("name")
+        async def command(
+            ctx: tanjun.abc.Context,
+            argument: typing.Annotated[
+                annotations.Default[annotations.Str, "nyaa"], "meow"  # noqa: F821  # type: ignore
+            ],
+        ) -> None:
+            ...
 
     assert command.build().options == [
         hikari.CommandOption(
@@ -1479,13 +1495,15 @@ def test_with_positional():
 
 
 def test_with_generic_positional():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("name")
-    @tanjun.as_slash_command("boop", "description")
-    async def callback(
-        ctx: tanjun.abc.Context, beep: typing.Annotated[annotations.Positional[annotations.Str], "eat"]  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("name")
+        @tanjun.as_slash_command("boop", "description")
+        async def callback(
+            ctx: tanjun.abc.Context, beep: typing.Annotated[annotations.Positional[annotations.Str], "eat"]  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -1532,10 +1550,12 @@ def test_with_greedy():
 
 
 def test_with_generic_greedy():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    async def callback(ctx: tanjun.abc.Context, meep: annotations.Greedy[annotations.Str]):  # type: ignore
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        async def callback(ctx: tanjun.abc.Context, meep: annotations.Greedy[annotations.Str]):  # type: ignore
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert len(callback.parser.arguments) == 1
@@ -1712,15 +1732,17 @@ def test_with_length_when_min_specificed():
 
 
 def test_with_generic_length():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("name", "description")
-    @tanjun.as_message_command("name")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.Length[123], "nom"],  # type: ignore
-        other_value: typing.Annotated[typing.Optional[annotations.Length[5544]], "meow"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("name", "description")
+        @tanjun.as_message_command("name")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.Length[123], "nom"],  # type: ignore
+            other_value: typing.Annotated[typing.Optional[annotations.Length[5544]], "meow"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert callback.build().options == [
         hikari.CommandOption(
@@ -1792,15 +1814,17 @@ def test_with_generic_length():
 
 
 def test_with_generic_length_when_min_specificed():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("name", "description")
-    @tanjun.as_message_command("name")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.Length[43, 5444], "nom"],  # type: ignore
-        other_value: typing.Annotated[typing.Optional[annotations.Length[32, 4343]], "meow"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("name", "description")
+        @tanjun.as_message_command("name")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.Length[43, 5444], "nom"],  # type: ignore
+            other_value: typing.Annotated[typing.Optional[annotations.Length[32, 4343]], "meow"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert callback.build().options == [
         hikari.CommandOption(
@@ -1977,15 +2001,17 @@ def test_with_generic_max(
     global value_
     value_ = value
 
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        number: typing.Annotated[annotations.Max[value_], "eee"],  # type: ignore
-        other_number: typing.Annotated[annotations.Max[value_], "eep"] = 54234,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            number: typing.Annotated[annotations.Max[value_], "eee"],  # type: ignore
+            other_number: typing.Annotated[annotations.Max[value_], "eep"] = 54234,  # type: ignore
+        ):
+            ...
 
     assert isinstance(callback.wrapped_command, tanjun.MessageCommand)
     assert isinstance(callback.wrapped_command.parser, tanjun.ShlexParser)
@@ -2252,15 +2278,17 @@ def test_with_generic_min(
     global value_
     value_ = value
 
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        number: typing.Annotated[annotations.Min[value_], "bee"],  # type: ignore
-        other_number: typing.Annotated[annotations.Min[value_], "buzz"] = 321,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            number: typing.Annotated[annotations.Min[value_], "bee"],  # type: ignore
+            other_number: typing.Annotated[annotations.Min[value_], "buzz"] = 321,  # type: ignore
+        ):
+            ...
 
     assert isinstance(callback.wrapped_command, tanjun.MessageCommand)
     assert isinstance(callback.wrapped_command.parser, tanjun.ShlexParser)
@@ -2790,15 +2818,17 @@ def test_with_generic_ranged(
     min_value_ = min_value
     max_value_ = max_value
 
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("command", "description")
-    @tanjun.as_message_command("command")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        number: typing.Annotated[annotations.Ranged[min_value_, max_value_], "meow"],  # type: ignore
-        other_number: typing.Annotated[annotations.Ranged[min_value_, max_value_], "nom"] = 443,  # type: ignore
-    ):
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("command", "description")
+        @tanjun.as_message_command("command")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            number: typing.Annotated[annotations.Ranged[min_value_, max_value_], "meow"],  # type: ignore
+            other_number: typing.Annotated[annotations.Ranged[min_value_, max_value_], "nom"] = 443,  # type: ignore
+        ):
+            ...
 
     assert isinstance(callback.wrapped_command, tanjun.MessageCommand)
     assert isinstance(callback.wrapped_command.parser, tanjun.ShlexParser)
@@ -2952,15 +2982,17 @@ def test_with_snowflake_or():
 
 
 def test_with_generic_snowflake_or_for_channel():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Channel], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Channel]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.Channel], "se"],  # type: ignore
+            value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Channel]], "x"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3032,15 +3064,17 @@ def test_with_generic_snowflake_or_for_channel():
 
 
 def test_with_generic_snowflake_or_for_member():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Member], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Member]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.Member], "se"],  # type: ignore
+            value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Member]], "x"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3112,15 +3146,19 @@ def test_with_generic_snowflake_or_for_member():
 
 
 def test_with_generic_snowflake_or_for_mentionable():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Mentionable], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Mentionable]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.Mentionable], "se"],  # type: ignore
+            value_2: typing.Annotated[
+                typing.Optional[annotations.SnowflakeOr[annotations.Mentionable]], "x"  # type: ignore
+            ] = None,
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3192,15 +3230,17 @@ def test_with_generic_snowflake_or_for_mentionable():
 
 
 def test_with_generic_snowflake_or_for_role():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Role], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Role]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.Role], "se"],  # type: ignore
+            value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Role]], "x"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3272,15 +3312,17 @@ def test_with_generic_snowflake_or_for_role():
 
 
 def test_with_generic_snowflake_or_for_user():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.User], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.User]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.User], "se"],  # type: ignore
+            value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.User]], "x"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3352,15 +3394,17 @@ def test_with_generic_snowflake_or_for_user():
 
 
 def test_with_generic_snowflake_or():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_message_command("command")
-    @tanjun.as_slash_command("yeet", "description")
-    async def callback(
-        ctx: tanjun.abc.Context,
-        value: typing.Annotated[annotations.SnowflakeOr[annotations.Bool], "se"],  # type: ignore
-        value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Bool]], "x"] = None,  # type: ignore
-    ) -> None:
-        ...
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_message_command("command")
+        @tanjun.as_slash_command("yeet", "description")
+        async def callback(
+            ctx: tanjun.abc.Context,
+            value: typing.Annotated[annotations.SnowflakeOr[annotations.Bool], "se"],  # type: ignore
+            value_2: typing.Annotated[annotations.SnowflakeOr[typing.Optional[annotations.Bool]], "x"] = None,  # type: ignore
+        ) -> None:
+            ...
 
     assert isinstance(callback.parser, tanjun.ShlexParser)
     assert isinstance(callback.wrapped_command, tanjun.SlashCommand)
@@ -3554,18 +3598,20 @@ def test_with_these_channels(
     assert option.max_value is None
 
 
-def test_with_generic_these_channels():
-    @annotations.with_annotated_args(follow_wrapped=True)
-    @tanjun.as_slash_command("name", "description")
-    @tanjun.as_message_command("name")
-    async def command(
-        ctx: tanjun.abc.Context,
-        bb: typing.Annotated[annotations.TheseChannels[hikari.GuildChannel], "nep"],  # type: ignore
-        bat: typing.Annotated[
-            typing.Optional[annotations.TheseChannels[hikari.GuildVoiceChannel, hikari.PrivateChannel]], "bip"  # type: ignore
-        ] = None,
-    ):
-        ...
+def test_with_generic_these_channels():  # noqa: CFQ001
+    with pytest.warns(DeprecationWarning):
+
+        @annotations.with_annotated_args(follow_wrapped=True)
+        @tanjun.as_slash_command("name", "description")
+        @tanjun.as_message_command("name")
+        async def command(
+            ctx: tanjun.abc.Context,
+            bb: typing.Annotated[annotations.TheseChannels[hikari.GuildChannel], "nep"],  # type: ignore
+            bat: typing.Annotated[
+                typing.Optional[annotations.TheseChannels[hikari.GuildVoiceChannel, hikari.PrivateChannel]], "bip"  # type: ignore
+            ] = None,
+        ):
+            ...
 
     expected_types_1 = {
         hikari.ChannelType.GUILD_CATEGORY,

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -1778,13 +1778,13 @@ def test_parse_message_id(value: typing.Union[int, str], expected: tuple[typing.
 def test_defragment_url():
     result = tanjun.conversion.defragment_url("https://s//s/s/s/s/d#b")
 
-    assert result == urllib.parse.DefragResult(url="https://s//s/s/s/s/d", fragment="b")  # type: ignore
+    assert result == urllib.parse.DefragResult(url="https://s//s/s/s/s/d", fragment="b")
 
 
 def test_defragment_url_when_wrapped():
     result = tanjun.conversion.defragment_url("<https://s//s/s/s/s/b#a>")
 
-    assert result == urllib.parse.DefragResult(url="https://s//s/s/s/s/b", fragment="a")  # type: ignore
+    assert result == urllib.parse.DefragResult(url="https://s//s/s/s/s/b", fragment="a")
 
 
 def test_parse_url():


### PR DESCRIPTION
### Summary
<!-- Small summary of the merge request -->

### Checklist
<!-- Make sure to tick all the following boxes by putting an `x` in between (like this `[x]`) -->
- [ ] I have run `nox` and all the pipelines have passed.
- [ ] I have made unittests according to the code I have added/modified/deleted.

### Related issues
<!--
To mention an issue use `#issue-id` and to mention a merge request use `!merge-request-id`
To close/fix an issue use `Close #issue-id` or `Fix #issue-id` (depending on the merge request)
-->
